### PR TITLE
Improved report generation

### DIFF
--- a/configExample.json
+++ b/configExample.json
@@ -23,7 +23,9 @@
     "profiles": "/mnt/hds/proj/cust015/mlst/references/profiles",
     "references": "/mnt/hds/proj/cust015/mlst/references/definitions_locisplit",
     "_comment": "Root folder for ALL output",
-    "results": "/mnt/hds/proj/cust015/mlst/results"
+    "results": "/mnt/hds/proj/cust015/mlst/results",
+    "_comment": "Root folder for input project folders",
+    "input": "/home/isak.sylvin/CG_MLST/cust015/isak_dev/indata"
   },
 
   "_comment": "Database/Flask configuration",

--- a/microSALT/cli.py
+++ b/microSALT/cli.py
@@ -92,7 +92,7 @@ def sample(ctx, sample_dir):
 
   scientist.load_lims_sample_info(os.path.normpath(sample_dir).split('_')[0])
   garbageman.scrape_sample()
-  codemonkey.gen_pdf(scientist.data['CG_ID_project'])
+  codemonkey.gen_html(scientist.data['CG_ID_project'])
   codemonkey.gen_csv(scientist.data['CG_ID_project'])
   done()
 
@@ -106,7 +106,7 @@ def project(ctx, project_dir):
 
   garbageman.scrape_project()
   projname = os.path.basename(os.path.normpath(project_dir)).split('_')[0]
-  codemonkey.gen_pdf(projname)
+  codemonkey.gen_html(projname)
   codemonkey.gen_csv(projname)
   done()
 
@@ -116,7 +116,7 @@ def project(ctx, project_dir):
 def report(ctx, project_name):
   """Re-generates reports for a project"""
   codemonkey = Reporter(ctx.obj['config'], ctx.obj['log'])
-  codemonkey.gen_pdf(project_name)
+  codemonkey.gen_html(project_name)
   codemonkey.gen_csv(project_name)
   done()
 

--- a/microSALT/cli.py
+++ b/microSALT/cli.py
@@ -118,4 +118,11 @@ def report(ctx, project_name):
   codemonkey = Reporter(ctx.obj['config'], ctx.obj['log'])
   codemonkey.gen_pdf(project_name)
   codemonkey.gen_csv(project_name)
-  done() 
+  done()
+
+@root.command()
+@click.pass_context
+def view(ctx):
+  """Starts a webserver at http://127.0.0.1:5000 for interactive viewing"""
+  codemonkey = Reporter(ctx.obj['config'], ctx.obj['log'])
+  codemonkey.start_web()

--- a/microSALT/server/views.py
+++ b/microSALT/server/views.py
@@ -1,6 +1,8 @@
 from datetime import date
 from flask import Flask, render_template
 import logging
+from xhtml2pdf import pisa
+from io import StringIO, BytesIO
 
 from sqlalchemy import *
 from sqlalchemy.orm import sessionmaker
@@ -62,3 +64,26 @@ def report_page(project, organism_group):
         samples = sample_info,
         date = date.today().isoformat(),
         version = versiondict)
+
+@app.route('/microSALT/<project>/download')
+def download_page(project):
+    #Data charging
+    sample_info = session.query(Samples).filter(Samples.CG_ID_project==project)
+    sample_info = sorted(sample_info, key=lambda sample: int(sample.CG_ID_sample.replace(sample.CG_ID_project, '')[1:]))
+    versions = session.query(Versions).all()
+    versiondict = dict()
+    for version in versions:
+      name = version.name[8:]
+      versiondict[name] = version.version
+
+    create_pdf(render_template('report_page.html', samples = sample_info, date = date.today().isoformat(), version = versiondict))
+    return ('', 204)
+
+def create_pdf(pdf_data):
+  """Function to generate pdf files"""
+  file = open('example.pdf', 'w+b')
+  #These work but break template
+  #pisa.CreatePDF(BytesIO(pdf_data.encode('utf-8')).getvalue(), file)
+  pisa.CreatePDF(StringIO(pdf_data), file)
+  file.close()
+

--- a/microSALT/server/views.py
+++ b/microSALT/server/views.py
@@ -73,7 +73,9 @@ def gen_reportdata(pid, organism_group='all'):
   sample_info = sorted(sample_info, key=lambda sample: \
                 int(sample.CG_ID_sample.replace(sample.CG_ID_project, '')[1:]))
   for s in sample_info:
-    if s.ST < 0:
+    if s.ST > 0 and s.Customer_ID_sample.startswith('NTC'):
+      s.ST = 'Control'   
+    elif s.ST < 0:
       if s.ST == -1:
         s.ST = 'Control'
       elif s.ST == -4:

--- a/microSALT/server/views.py
+++ b/microSALT/server/views.py
@@ -23,6 +23,7 @@ mail_ext.init_app(app)
 log = logging.getLogger('werkzeug')
 log.setLevel(logging.CRITICAL)
 
+
 @app.route('/')
 def start_page():
     projects = session.query(Projects).all()
@@ -52,19 +53,43 @@ def project_page(project):
 
 @app.route('/microSALT/<project>/<organism_group>')
 def report_page(project, organism_group):
-    if organism_group == "all":
-        sample_info = session.query(Samples).filter(Samples.CG_ID_project==project)
-    else:
-        sample_info = session.query(Samples).\
-        filter(Samples.organism==organism_group, Samples.CG_ID_project==project)
-    sample_info = sorted(sample_info, key=lambda sample: int(sample.CG_ID_sample.replace(sample.CG_ID_project, '')[1:]))
-    versions = session.query(Versions).all()
-    versiondict = dict()
-    for version in versions:
-      name = version.name[8:]
-      versiondict[name] = version.version
+    sample_info = gen_reportdata(project, organism_group)
 
     return render_template('report_page.html',
-        samples = sample_info,
+        samples = sample_info['samples'],
         date = date.today().isoformat(),
-        version = versiondict)
+        version = sample_info['versions'])
+
+def gen_reportdata(pid, organism_group='all'):
+  """ Queries database for all necessary information for the reports """
+  output = dict()
+  output['samples'] = list()
+  output['versions'] = dict()
+  if organism_group=='all':
+    sample_info = session.query(Samples).filter(Samples.CG_ID_project==pid)
+  else:
+    sample_info = session.query(Samples).\
+                  filter(Samples.organism==organism_group, Samples.CG_ID_project==project)
+  sample_info = sorted(sample_info, key=lambda sample: \
+                int(sample.CG_ID_sample.replace(sample.CG_ID_project, '')[1:]))
+  for s in sample_info:
+    if s.ST < 0:
+      if s.ST == -1:
+        s.ST = 'Control'
+      elif s.ST == -4:
+        s.ST = 'Novel'
+      else:
+        s.ST='None'
+
+    s.threshold = 'Passed'
+    for seq_type in s.seq_types:
+      if seq_type.identity < 100.0:
+        s.threshold = 'Failed'
+    output['samples'].append(s)
+
+  versions = session.query(Versions).all()
+  for version in versions:
+    name = version.name[8:]
+    output['versions'][name] = version.version
+
+  return output

--- a/microSALT/utils/reporter.py
+++ b/microSALT/utils/reporter.py
@@ -4,9 +4,17 @@
 #!/usr/bin/env python
 import requests
 import time
+import os
+import smtplib
+from os.path import basename
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from email.mime.image import MIMEImage
+from email.mime.application import MIMEApplication
 from multiprocessing import Process
 from microSALT.server.views import app, session
 from microSALT.store.orm_models import Samples
+from microSALT.store.lims_fetcher import LIMS_Fetcher
 
 class Reporter():
 
@@ -16,19 +24,42 @@ class Reporter():
     self.logger = log
     self.server = Process(target=app.run)
 
-
   def gen_pdf(self, name):
+    self.name = name
+    self.start_web()
+    self.name = name
+    ticketFinder = LIMS_Fetcher(self.config, self.logger)
+    ticketFinder.load_lims_project_info(name)
+    #wget.download("http://127.0.0.1:5000/microSALT/{}/all -o {}_microSALT.html".format(name, ticketFinder.data['Customer_ID_project']))
+    r = requests.get("http://127.0.0.1:5000/microSALT/{}/all".format(name), allow_redirects=True)
+    outname = "{}_microSALT.html".format(ticketFinder.data['Customer_ID_project'])
+    open(outname, 'wb').write(r.content)
+    self.logger.info("Generated project {} in file {}".format(name, outname))
+    self.kill_flask()
+    self.mail_pdf(outname)
+
+  def mail_pdf(self, file_name):
+    msg = MIMEMultipart()
+    msg['Subject'] = '{} Report'.format(file_name.split('_')[0])
+    msg['From'] = 'microSALT'
+    msg['To'] = self.config['regex']['mail_recipient']
+    #msg.attach(MIMEText(open(file_name).read()))
+    part = MIMEApplication(open(file_name).read())
+    part.add_header('Content-Disposition', 'attachment; filename="%s"' % os.path.basename(file_name))
+    msg.attach(part)
+
+
+    s = smtplib.SMTP('localhost')
+    s.connect()
+    s.sendmail(msg['From'], msg['To'], msg.as_string())
+    s.quit()
+    self.logger.info("Mail containing report sent to {}".format(msg['To'])) 
+
+  def start_web(self):
     self.server.start()
+    self.logger.info("Started webserver on http://127.0.0.1:5000/")
     #Hinders requests before server goes up
     time.sleep(0.05)
-    self.name = name
- 
-    #Poke webpage
-    r= requests.get('http://127.0.0.1:5000/microSALT/{}/download'.format(name))
-    self.logger.info("Webserver yieled code {} on request".format(r.status_code))
-
-    self.kill_flask()
-    self.logger.info("Created {}.pdf in current directory".format(name))
 
   def gen_csv(self, name):
     excel = open("{}.csv".format(name), "w+")
@@ -58,4 +89,5 @@ class Reporter():
   def kill_flask(self):
     self.server.terminate()
     self.server.join()
+    self.logger.info("Closed webserver on http://127.0.0.1:5000/")
 

--- a/microSALT/utils/reporter.py
+++ b/microSALT/utils/reporter.py
@@ -2,8 +2,8 @@
    By: Isak Sylvin, @sylvinite"""
 
 #!/usr/bin/env python
+import requests
 import time
-import weasyprint
 from multiprocessing import Process
 from microSALT.server.views import app, session
 from microSALT.store.orm_models import Samples
@@ -16,13 +16,17 @@ class Reporter():
     self.logger = log
     self.server = Process(target=app.run)
 
+
   def gen_pdf(self, name):
     self.server.start()
     #Hinders requests before server goes up
     time.sleep(0.05)
     self.name = name
-    weasyprint.HTML('http://127.0.0.1:5000/microSALT/{}/all'.format(self.name))\
-    .write_pdf('{}.pdf'.format(self.name))
+ 
+    #Poke webpage
+    r= requests.get('http://127.0.0.1:5000/microSALT/{}/download'.format(name))
+    self.logger.info("Webserver yieled code {} on request".format(r.status_code))
+
     self.kill_flask()
     self.logger.info("Created {}.pdf in current directory".format(name))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ genologics
 pymysql
 pyyaml
 sqlalchemy
-xhtml2pdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ genologics
 pymysql
 pyyaml
 sqlalchemy
-weasyprint
+xhtml2pdf


### PR DESCRIPTION
- Removed weasyprint the HPC disagreed with it.
- Replaced PDF generation with HTML generation
- Both reports are now generated from shared function
- HTML automatically downloaded and e-mailed when finishing
- CSV now generated with correct name under input folder
- NTC sample prefix automatically declares the sample as 'control'