### PR TITLE
Last second fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,6 @@ export MICROSALT_CONFIG=/MY/FAV/FOLDER/config.json
 
 __Then edit the fields to match your environment__.
 
-### Genologics Configuration
-_Genologics ( https://github.com/SciLifeLab/genologics ) is likely already installed on your system. If such, this section can be skipped_
-
-Create `$HOME/.genologicsrc` with the following formatting:
-```
-[genologics]
-BASEURI=https://yourlims.corporation.se/
-USERNAME=your_username
-PASSWORD=your_password
-[logging]
-MAIN_LOG=/tmp/lims.log
-```
-
-
 ## Usage
 * `microSALT analyse` contains functions to start sbatch job(s) & produce output to `folders['results']`. Afterwards the parsed results  are uploaded to the SQL back-end and produce reports (HTML), which are then automatically e-mailed to the user.
 * `microSALT utils` contains various functionality, including adding manually new reference organisms and re-generating reports.

--- a/configExample.json
+++ b/configExample.json
@@ -56,6 +56,6 @@
   "genologics": {
     "baseuri": "https://lims.facility.se/",
     "username": "genologicsuser",
-    "password: "mypassword123"
+    "password": "mypassword123"
   }
 }

--- a/configExample.json
+++ b/configExample.json
@@ -51,4 +51,11 @@
     "res_id": 97,
     "res_span": 0.9
   }
+
+  "_comment": "Genologics temporary configuration file",
+  "genologics": {
+    "baseuri": "https://lims.facility.se/",
+    "username": "genologicsuser",
+    "password: "mypassword123"
+  }
 }

--- a/configExample.json
+++ b/configExample.json
@@ -50,7 +50,7 @@
     "mlst_span": 0.9,
     "res_id": 97,
     "res_span": 0.9
-  }
+  },
 
   "_comment": "Genologics temporary configuration file",
   "genologics": {

--- a/configExample.json
+++ b/configExample.json
@@ -48,8 +48,8 @@
     "mlst_id": 100,
     "mlst_novel_id": 99.5,
     "mlst_span": 0.9,
-    "res_id": 97,
-    "res_span": 0.9
+    "motif_id": 97,
+    "motif_span": 0.9
   },
 
   "_comment": "Genologics temporary configuration file",

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ conda create -y -n $rname python=3.6
 #source deactivate
 source activate $rname
 conda config --add channels bioconda
-conda install -y -c bioconda blast=2.5.0=hc0b0e79_3 spades=3.12.0=py36_0 trimmomatic=0.38=1 samtools=1.6=0 picard=2.18.26=0
+conda install -y -c bioconda blast=2.5.0=hc0b0e79_3 spades=3.12.0=py36_0 trimmomatic=0.38=1 samtools=1.6=0 picard=2.18.26=0 bwa==0.7.15=1
 if [[ $type = "prod" ]]; then
     pip install -r requirements.txt --no-cache-dir && pip install .
 elif [[ $type = "dev" ]] || [[ $type = "stage" ]]; then

--- a/microSALT/__init__.py
+++ b/microSALT/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 from flask import Flask
 
-__version__ = '2.6.0'
+__version__ = '2.7.0'
 
 app = Flask(__name__, template_folder='server/templates')
 app.config.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')

--- a/microSALT/server/views.py
+++ b/microSALT/server/views.py
@@ -129,7 +129,7 @@ def gen_reportdata(pid='all', organism_group='all'):
           s.threshold = 'Failed'
 
       if near_hits > 0 and s.threshold == 'Passed':
-        s.ST_status = 'Unknown ({} novel alleles)'.format(near_hits)
+        s.ST_status = 'Unknown ({} alleles)'.format(near_hits)
     else:
       s.threshold = 'Failed'
 
@@ -145,8 +145,8 @@ def gen_reportdata(pid='all', organism_group='all'):
 
     #Resistence filter
     for r in s.resistances:
-      if (s.ST > 0 or 'Novel' in s.ST_status ) and (r.identity >= config["threshold"]["res_id"] and \
-      r.span >= config["threshold"]["res_span"]) or (s.ST < 0 and not 'Novel' in s.ST_status):
+      if (s.ST > 0 or 'Novel' in s.ST_status ) and (r.identity >= config["threshold"]["motif_id"] and \
+      r.span >= config["threshold"]["motif_span"]) or (s.ST < 0 and not 'Novel' in s.ST_status):
         r.threshold = 'Passed'
       else:
         r.threshold = 'Failed'

--- a/microSALT/server/views.py
+++ b/microSALT/server/views.py
@@ -111,13 +111,6 @@ def gen_reportdata(pid='all', organism_group='all'):
     s.Customer_ID_sample.startswith('CTRL') or s.Customer_ID_sample.startswith('Neg') or \
     s.Customer_ID_sample.startswith('blank') or s.Customer_ID_sample.startswith('dual-NTC'):
       s.ST_status = 'Control (prefix)'
-    elif s.ST < 0:
-      if s.ST == -1:
-        s.ST_status = 'Invalid data'
-      elif s.ST <= -4 or s.ST == -2:
-        s.ST_status = 'Novel'
-      else:
-        s.ST_status='None'
 
     if 'Control' in s.ST_status or s.ST == -1:
       s.threshold = '-'
@@ -136,9 +129,19 @@ def gen_reportdata(pid='all', organism_group='all'):
           s.threshold = 'Failed'
 
       if near_hits > 0 and s.threshold == 'Passed':
-        s.ST_status = 'Novel alleles ({})'.format(near_hits)
+        s.ST_status = 'Unknown ({} novel alleles)'.format(near_hits)
     else:
       s.threshold = 'Failed'
+
+    if not 'Control' in s.ST_status and s.ST < 0:
+      if s.ST == -1:
+        s.ST_status = 'Invalid data'
+      elif (s.ST <= -4 or s.ST == -2) and s.threshold == 'Passed':
+        s.ST_status = 'Novel'
+      elif (s.ST <= -4 or s.ST == -2) and s.threshold == 'Failed':
+        s.ST_status = 'Unknown'
+      else:
+        s.ST_status='None'
 
     #Resistence filter
     for r in s.resistances:

--- a/microSALT/store/lims_fetcher.py
+++ b/microSALT/store/lims_fetcher.py
@@ -6,14 +6,13 @@ import re
 from datetime import datetime
 from genologics.lims import Lims
 # Should probably call these items directly since we're now up to 3 config files
-from genologics.config import BASEURI,USERNAME,PASSWORD
 from genologics.entities import Project, Sample
 
 class LIMS_Fetcher():
 
   def __init__(self, config, log):
     self.data = {}
-    self.lims = Lims(BASEURI, USERNAME, PASSWORD)
+    self.lims = Lims(config['genologics']['baseuri'], config['genologics']['username'], config['genologics']['password'])
     self.logger = log
     self.config = config
 

--- a/microSALT/utils/reporter.py
+++ b/microSALT/utils/reporter.py
@@ -6,6 +6,7 @@ import json
 import requests
 import time
 import os
+import socket
 import sys
 import smtplib
 
@@ -110,7 +111,7 @@ class Reporter():
       msg['Subject'] = '{} ({}) Reports'.format(self.name, file_name[0].split('_')[0])
     else:
       msg['Subject'] = '{} ({}) Failed Generating Report'.format(self.name, file_name[0].split('_')[0])
-    msg['From'] = 'microSALT'
+    msg['From'] = 'microSALT@{}'.format(socket.gethostname())
     msg['To'] = self.config['regex']['mail_recipient']
    
     if not self.error: 

--- a/microSALT/utils/reporter.py
+++ b/microSALT/utils/reporter.py
@@ -189,6 +189,9 @@ class Reporter():
 
       report[s.CG_ID_sample]['blast_pubmlst'] = {'sequence_type':s.ST_status, 'thresholds':s.threshold}
       report[s.CG_ID_sample]['quast_assembly'] = {'estimated_genome_length':s.genome_length, 'gc_percentage':float(s.gc_percentage), 'n50':s.n50, 'necessary_contigs':s.contigs}
+      report[s.CG_ID_sample]['picard_markduplicate'] = {'insert_size':s.insert_size, 'duplication_rate':s.duplication_rate}
+      report[s.CG_ID_sample]['microsalt_samtools_stats'] = {'total_reads':s.total_reads, 'mapped_rate':s.mapped_rate, 'average_coverage':s.average_coverage, 
+                                                            'coverage_10x':s.coverage_10x, 'coverage_30x':coverage_30x, 'coverage_50x':coverage_50x, 'coverage_100x':coverage_100x}
 
       for r in s.resistances:
         if not (r.gene in report[s.CG_ID_sample]['blast_resfinder_resistence']) and r.threshold == 'Passed':

--- a/microSALT/utils/reporter.py
+++ b/microSALT/utils/reporter.py
@@ -190,8 +190,9 @@ class Reporter():
       report[s.CG_ID_sample]['blast_pubmlst'] = {'sequence_type':s.ST_status, 'thresholds':s.threshold}
       report[s.CG_ID_sample]['quast_assembly'] = {'estimated_genome_length':s.genome_length, 'gc_percentage':float(s.gc_percentage), 'n50':s.n50, 'necessary_contigs':s.contigs}
       report[s.CG_ID_sample]['picard_markduplicate'] = {'insert_size':s.insert_size, 'duplication_rate':s.duplication_rate}
-      report[s.CG_ID_sample]['microsalt_samtools_stats'] = {'total_reads':s.total_reads, 'mapped_rate':s.mapped_rate, 'average_coverage':s.average_coverage, 
-                                                            'coverage_10x':s.coverage_10x, 'coverage_30x':coverage_30x, 'coverage_50x':coverage_50x, 'coverage_100x':coverage_100x}
+      report[s.CG_ID_sample]['microsalt_samtools_stats'] = {'total_reads':s.total_reads, 'mapped_rate':s.mapped_rate, 'average_coverage':s.average_coverage, \
+                                                            'coverage_10x':s.coverage_10x, 'coverage_30x':s.coverage_30x, \
+                                                            'coverage_50x':s.coverage_50x, 'coverage_100x':s.coverage_100x}
 
       for r in s.resistances:
         if not (r.gene in report[s.CG_ID_sample]['blast_resfinder_resistence']) and r.threshold == 'Passed':
@@ -223,7 +224,7 @@ class Reporter():
     s.connect()
     s.sendmail(msg['From'], msg['To'], msg.as_string())
     s.quit()
-    self.logger.info("Mail containing report sent to {}".format(msg['To'])) 
+    self.logger.info("Mail containing report sent to {} from {}".format(msg['To'], msg['From'])) 
 
   def start_web(self):
     self.server.start()


### PR DESCRIPTION
This PR adds the following features:

- JSON is generated in runfolder when doing a normal analysis
- JSON now contains more QC data
- E-mailing from the nodes _might_ work now
- Novel alleles and Novel+Thresholds failed are now classed as Unknown
- Genologics config is now read from the microSALT config 

**How to test**:
On hasta:

0. If you have any files named *genologics* in your home directory. Temporarily rename them.
1. Pull branch into /home/proj/stage/bin/git/microSALT
2. us
3. source activate S_microSALT
4. export MICROSALT_CONFIG=/home/proj/dropbox/microSALT.json
4.1 doublecheck that the paths in /home/proj/dropbox/microSALT.json works for you
5. pip install .
6. microSALT analyse sample ACC5710A5 --email (email)
7. microSALT analyse project ACC5710 --email (email)

**Expected outcome**:

For steps 6 and 7 the following is expected to happen:
- An e-mail will be sent with a typing and qc report upon slurm completion. It is ok if it doesn't. If it doesnt, generate the e-mail with the `microSALT utils report` command.
- Sample A5, report sequence type as 'Unknown' in the typing report
- In the results folder for sample/project, there should be a json file. The contents of at least the QC report should be within it.

In other words, screenshots of the e-mailed typing report and the contents of the json file should be sufficient.

**Review:**
- [x] reviewed by self @sylvinite 
- [x] tests executed by @talnor 
- [x] deployed approved @ingkebil 

This is minor **version bump** because the code can't alter the results in a mysterious way; is backwards compatible, and will either outright crash or not generate the requested change; if it is incorrect.