### PR TITLE
Improved organism check

### DIFF
--- a/microSALT/__init__.py
+++ b/microSALT/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 from flask import Flask
 
-__version__ = '2.8.2'
+__version__ = '2.8.3'
 
 app = Flask(__name__, template_folder='server/templates')
 app.config.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')

--- a/microSALT/store/lims_fetcher.py
+++ b/microSALT/store/lims_fetcher.py
@@ -136,6 +136,7 @@ class LIMS_Fetcher():
     else:
       prio = ""
 
+
     try:
       self.data.update({'CG_ID_project': sample.project.id,
                            'CG_ID_sample': sample.id,
@@ -167,13 +168,17 @@ class LIMS_Fetcher():
       for target in orgs:
         hit = 0
         for piece in organism:
-          if piece in target:
-            hit +=1
-          #For when people misspell the strain in the orderform
-          elif piece == "pneumonsiae" and "pneumoniae" in target:
-            hit +=1
+          if len(piece) == 1:
+            if target.startswith(piece):
+              hit += 1
           else:
-            break
+            if piece in target:
+              hit +=1
+            #For when people misspell the strain in the orderform
+            elif piece == "pneumonsiae" and "pneumoniae" in target:
+              hit +=1
+            else:
+              break
         if hit == len(organism):
           return target
     except Exception as e:

--- a/microSALT/utils/job_creator.py
+++ b/microSALT/utils/job_creator.py
@@ -498,6 +498,8 @@ class Job_Creator():
         os.makedirs(self.finishdir)
       try:
         self.organism = self.lims_fetcher.get_organism_refname(self.name)
+        if not self.organism:
+          self.organism = self.lims_fetcher.data['organism']
         # This is one job
         self.batchfile = "{}/runfile.sbatch".format(self.finishdir)
         batchfile = open(self.batchfile, "w+")

--- a/microSALT/utils/scraper.py
+++ b/microSALT/utils/scraper.py
@@ -227,6 +227,8 @@ class Scraper():
     """Scrapes all BLAST output in a folder"""
     q_list = glob.glob("{}/blast/loci_query_*".format(self.sampledir))
     organism = self.lims_fetcher.get_organism_refname(self.name)
+    if not organism:
+      organism = self.lims_fetcher.data['organism']
     self.db_pusher.upd_rec({'CG_ID_sample' : self.name}, 'Samples', {'organism': organism})
 
     for file in q_list:
@@ -237,7 +239,7 @@ class Scraper():
       self.db_pusher.upd_rec({'CG_ID_sample':self.name}, 'Samples', {'ST':ST})
       self.logger.info("Sample {} received ST {}".format(self.name, ST))
     except Exception as e:
-      self.logger.error("{}".format(str(e)))
+      self.logger.warning("Unable to type sample {} due to data value '{}'".format(self.name, str(e)))
 
   def scrape_single_loci(self, infile):
     """Scrapes a single blast output file for MLST results"""


### PR DESCRIPTION
# Description
The features of this PR primarily concerns bioinformaticians

* microSALT now more aggressively checks the organism supplied
* microSALT now uses the unfiltered organism name more readily in reports

This change was prompted by S. pseudomonas incorrectly identifying as Kleb(s)iella pseudomonas.

## Primary function of PR
- [X] Hotfix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

# Testing
microSALT analysis should be run on one of the misbehaving samples (ACC5746A8).
The log should warn about the exception, but both the Typing and QC report should report the correct organism (albeit the Typing report defaulting on about every data point since no pubMLST reference exists).

## Test results
Both reports were successfully generated and contained the correct organism 'S. pseudomonas' instead of the previously incorrect 'Klebsiella pseudomonas' one.

# Sign-offs
- [X] Code reviewed by @sylvinite
- [X] Code tested by @sylvinite
- [x] Approved to run at Clinical-Genomics by @ingkebil
