### PR TITLE
HOTFIX: Improved fastq-file inclusion for analysis

### DIFF
--- a/microSALT/__init__.py
+++ b/microSALT/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 from flask import Flask
 
-__version__ = '2.8.10'
+__version__ = '2.8.11'
 
 app = Flask(__name__, template_folder='server/templates')
 app.config.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')

--- a/microSALT/utils/job_creator.py
+++ b/microSALT/utils/job_creator.py
@@ -79,8 +79,8 @@ class Job_Creator():
             raise Exception("Some fastq files are unresolved symlinks in directory {}.".format(self.indir))
 
         #Make sure both mates exist
-        if file_match[1] == '1':
-          pairno = '2'
+        if file_match[1] == '1' or file_match[1] == '2':
+          pairno = 2-1%int(file_match[1]) #1->2, 2->1
           #Construct mate name
           pairname = "{}{}{}".format(file_match.string[:file_match.end(1)-1] , pairno, \
                       file_match.string[file_match.end(1):file_match.end()])
@@ -88,8 +88,6 @@ class Job_Creator():
             files.pop( files.index(pairname) )
             verified_files.append(file_match[0])
             verified_files.append(pairname)
-        elif file_match[1] == '2':
-          pass
         else:
           raise Exception("Some fastq files have no mate in directory {}.".format(self.indir))
     if verified_files == []:
@@ -100,7 +98,7 @@ class Job_Creator():
       bsize = bsize >> 20
       if bsize > 1000:
         self.logger.warning("Input fastq {} exceeds 1000MB".format(vfile))
-    return verified_files
+    return sorted(verified_files)
  
   def create_assemblysection(self):
     batchfile = open(self.batchfile, "a+")
@@ -173,7 +171,6 @@ class Job_Creator():
     ref = "{}/{}.fasta".format(self.config['folders']['genomes'],self.lims_fetcher.data['reference'])
     localdir = "{}/alignment".format(self.finishdir)
     outbase = "{}/{}_{}".format(localdir, self.name, self.lims_fetcher.data['reference'])
-    files = self.verify_fastq()
 
     #Create run
     batchfile = open(self.batchfile, "a+")


### PR DESCRIPTION
# Description
The features of this PR primarily concerns bioinformaticians

The changes in this PR guarantees that all input files are used for the microbial analysis to a greater degree.
The changes presented here were made in response to the identification that some projects did not have all input files included during analysis. This would in turn mean that microSALT underrepresented the amount of reads for "Total Reads".

## Primary function of PR
- [X] Hotfix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

# Testing
_Basic test routine:_
- _`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-microsalt-stage.sh verify_fix`_
- _`us`_
- _`source activate S_microSALT`_
- _`microSALT analyse project MIC3109`_
- _`microSALT analyse sample ACC5955A9`_

Verify that the results for projects MIC3109 are consistent with those presented to those attached in AMSystem doc 1490:9 section 2.7.
Verify that the `runfile.sbatch` for ACC5955A9 uses all the fastq files for ACC5955A9. These files are located two directories down from `/home/proj/stage/microbial/fastq`.

## Test results

The QC results for MIC3109 are within the approved difference. They are identical except for all values related to coverage, which differ by less than 0.5%.

All fastq files for ACC5955A9 (in /home/proj/stage/microbial/fastq/ACC5955/ACC5955A9 ) are present in the relevant runfile.sbatch

# Sign-offs
- [x] Code reviewed by @sylvinite
- [x] Code tested by @sylvinite 
- [x] Approved to run at Clinical-Genomics by @ingkebil
