### PR TITLE
Fix percentage of ordered reads in QC-report

### DIFF
--- a/microSALT/__init__.py
+++ b/microSALT/__init__.py
@@ -8,7 +8,7 @@ import sys
 from flask import Flask
 from distutils.sysconfig import get_python_lib
 
-__version__ = '2.8.24'
+__version__ = '2.8.25'
 
 app = Flask(__name__, template_folder='server/templates')
 app.config.setdefault('SQLALCHEMY_DATABASE_URI', 'sqlite:///:memory:')

--- a/microSALT/server/templates/alignment_page.html
+++ b/microSALT/server/templates/alignment_page.html
@@ -106,7 +106,7 @@
                           <td class="text-right">0
                         {% else %}
                           {% if sample.application_tag %}
-                            {% set bp_perc = ((sample.total_reads/((sample.application_tag[-1:]|float)*10000))|round(2)) %}
+                            {% set bp_perc = ((sample.total_reads*100/((sample.application_tag[-1:]|float)*2000000))|round(2)) %}
                           {% else %}
                             {% set bp_perc = 0.0 %}
                           {% endif %}


### PR DESCRIPTION
# Description
_The features of this PR primarily concerns end-users/bioinformaticians/internals_

_The percentage of ordered reads in the 'Antal Reads' column of the QC-report showed incorrect numbers. This was due to reads vs. read pairs confusion regarding the information in the apptags._

_The percentage of ordered reads will now be divided by 2._

## Primary function of PR
- [X] Hotfix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

# Testing
_This is a description of the tests necessary to verify the stability of the PR._

_Basic test routine:_
- _`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-microsalt-stage.sh pct_reads_fix`_
- _Select installer options "S_microSALT" , "release" and "pct_reads_fix"_
- _`us`_
- _`source activate S_microSALT`_
- _`export MICROSALT_CONFIG=/home/proj/dropbox/microSALT.json`_
- _`microSALT analyse project MIC3109`_

_Verify that the percentage of ordered reads is correct (i.e. equals the total reads / 6*10^6 * 100). Also verify that the code changes doesn't generate any unexpected error messages or graphical glitches in the report._

## Test results
_All percentages calculated correctly. See results below._
_No error messages or glitches to report._

# Sign-offs
- [x] Code reviewed by @sylvinite
- [x] Code tested by @talnor
- [x] Approved to run at Clinical-Genomics by @ingkebil
