### PR TITLE
fix: select default branch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,11 +4,7 @@ set -e
 shopt -s nullglob
 
 #Suggests provided branch. Else suggests master
-if [ -z ${$1+x} ]; then
-    default_branch=$1
-else
-    default_branch="master"
-fi
+default_branch=${1-master}
 
 echo "Welcome to the microSALT installation script. Q to exit"
 while true; do


### PR DESCRIPTION
# Description
This PR fixes 

```
[0|0|650] θ63° [kenny.billiau@hasta:~/git/servers] [base] microsalt 14s ± bash resources/hasta.scilifelab.se/update-microsalt-stage.sh master
on the host hasta.scilifelab.se, continue
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2688  100  2688    0     0   8479      0 --:--:-- --:--:-- --:--:--  8452
/dev/fd/63: line 7: ${$1+x}: bad substitution
```

## Primary function of PR
- [ ] Hotfix
- [x] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

# Testing
- [ ] Install microsalt with /home/proj/stage/servers/resources/hasta.scilifelab.se/update-microsalt-stage.sh master

Expected outcome:
microSALT installs without errors.

## Test results
_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

# Sign-offs
- [x] Code reviewed by @sylvinite
- [ ] Code tested by @sylvinite ? ;)
- [ ] Approved to run at Clinical-Genomics by @ingkebil
