### PR TITLE
Duplicate loci hits are now obfuscated

### DIFF
--- a/microSALT/store/db_manipulator.py
+++ b/microSALT/store/db_manipulator.py
@@ -369,7 +369,7 @@ class DB_Manipulator:
 
   def setPredictor(self, cg_sid, pks=dict()):
     """ Helper function. Flags a set of seq_types as part of the final prediction.
-    Uses optional pks[loci][column] = VALUE dictionary to distinguish in scenarios where an allele number has multiple hits"""
+    Uses optional pks[PK_NAME] = VALUE dictionary to distinguish in scenarios where an allele number has multiple hits"""
     sample = self.session.query(Seq_types).filter(Seq_types.CG_ID_sample==cg_sid)
 
     if pks == dict():

--- a/microSALT/utils/scraper.py
+++ b/microSALT/utils/scraper.py
@@ -245,7 +245,7 @@ class Scraper():
       targ = ind+1
       while targ < len(hypo):
         ignore = False
-        if hypo[ind]["contig_name"] == hypo[targ]["contig_name"]:
+        if hypo[ind]["contig_name"] == hypo[targ]["contig_name"] or hypo[ind][identifier] == hypo[targ][identifier]:
           #Overlapping or shared gene 
           if (hypo[ind]["contig_start"] >= hypo[targ]["contig_start"] and hypo[ind]["contig_start"] <= hypo[targ]["contig_end"]) or\
               (hypo[ind]["contig_end"] >= hypo[targ]["contig_start"] and hypo[ind]["contig_end"] <= hypo[targ]["contig_end"]) or \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 biopython
 bs4
-click
+click==7.0
 flask
 flask_sqlalchemy
 pymysql


### PR DESCRIPTION
# Description

The features of this PR primarily concerns end-users.

When duplicate loci hits occur, only the best hit is displayed. Prior all loci hits were shown, which could be considered a debugging behaviour.

This is changed due to being explicitly requested, as to decrease confusion regarding results.

## Primary function of PR
- [X] Hotfix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

# Testing
The update is a hotfix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR.

Travis CI PR test may display difficulties due to the master branch running an incompatible click version.


## Test results
_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

# Sign-offs
- [x] Code tested by @sylvinite
- [x] Approved to run at Clinical-Genomics by @sylvinite
