### PR TITLE
Proper display of non pubMLST-compatible organisms

### DIFF
--- a/microSALT/__init__.py
+++ b/microSALT/__init__.py
@@ -10,7 +10,7 @@ import sys
 from flask import Flask
 from distutils.sysconfig import get_python_lib
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 app = Flask(__name__, template_folder="server/templates")
 app.config.setdefault("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")

--- a/microSALT/utils/referencer.py
+++ b/microSALT/utils/referencer.py
@@ -275,7 +275,7 @@ class Referencer:
 
     def organism2reference(self, normal_organism_name):
         """Finds which reference contains the same words as the organism
-       and returns it in a format for database calls."""
+       and returns it in a format for database calls. Returns empty string if none found"""
         orgs = os.listdir(self.config["folders"]["references"])
         organism = re.split(r"\W+", normal_organism_name.lower())
         try:

--- a/microSALT/utils/scraper.py
+++ b/microSALT/utils/scraper.py
@@ -167,9 +167,10 @@ class Scraper:
                 )
 
         organism = self.referencer.organism2reference(self.sample.get("organism"))
-        self.db_pusher.upd_rec(
-            {"CG_ID_sample": self.name}, "Samples", {"organism": organism}
-        )
+        if organism != '':
+            self.db_pusher.upd_rec(
+                {"CG_ID_sample": self.name}, "Samples", {"organism": organism}
+            )
         res_cols = self.db_pusher.get_columns("{}".format(type2db))
 
         try:

--- a/microSALT/utils/scraper.py
+++ b/microSALT/utils/scraper.py
@@ -167,7 +167,7 @@ class Scraper:
                 )
 
         organism = self.referencer.organism2reference(self.sample.get("organism"))
-        if organism != '':
+        if organism:
             self.db_pusher.upd_rec(
                 {"CG_ID_sample": self.name}, "Samples", {"organism": organism}
             )


### PR DESCRIPTION
# Description

The features of this PR primarily concerns end-users.
It resolves the issue of non-pubMLST compatible organisms (e.g. research samples) not correctly displaying their organism in the final report.

## Primary function of PR
- [x] Hotfix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

# Testing
The update is a hotfix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR.

# Sign-offs
- [x] Code tested by @sylvinite
- [ ] Approved to run at Clinical-Genomics by @sylvinite
