### PR TITLE
HOTFIX: Fetch reference version number for external references

### DIFF
--- a/microSALT/utils/referencer.py
+++ b/microSALT/utils/referencer.py
@@ -159,7 +159,6 @@ class Referencer:
                 st_link = entry.find_all("a")[1]["href"]
                 profiles_query = urllib.request.urlopen(st_link)
                 profile_no = profiles_query.readlines()[-1].decode("utf-8").split("\t")[0]
-                #profile_no = re.search(r"\d+", sample[2]).group(0)
                 if (
                     organ in self.organisms
                     and organ.replace("_", " ") not in self.updated
@@ -169,7 +168,6 @@ class Referencer:
                     )
                 ):
                     # Download definition files
-                    #st_link = prefix + entry.find_all("a")[1]["href"]
                     output = "{}/{}".format(self.config["folders"]["profiles"], organ)
                     urllib.request.urlretrieve(st_link, output)
                     # Update database
@@ -187,9 +185,8 @@ class Referencer:
                     os.makedirs(out)
                     for loci in entry.find_all("a"):
                         loci = loci["href"]
-                        lociname = os.path.basename(os.path.normpath(loci))
-                        input = prefix + loci
-                        urllib.request.urlretrieve(input, "{}/{}".format(out, lociname))
+                        lociname = os.path.normpath(loci).split("/")[-2] 
+                        urllib.request.urlretrieve(loci, "{}/{}".format(out, lociname))
                     # Create new indexes
                     self.index_db(out, ".tfa")
                 else:

--- a/microSALT/utils/referencer.py
+++ b/microSALT/utils/referencer.py
@@ -155,7 +155,6 @@ class Referencer:
                 if "escherichia_coli" in organ and "#1" in organ:
                     organ = organ[:-2]
                 currver = self.db_access.get_version("profile_{}".format(organ))
-                
                 st_link = entry.find_all("a")[1]["href"]
                 profiles_query = urllib.request.urlopen(st_link)
                 profile_no = profiles_query.readlines()[-1].decode("utf-8").split("\t")[0]

--- a/microSALT/utils/referencer.py
+++ b/microSALT/utils/referencer.py
@@ -155,7 +155,11 @@ class Referencer:
                 if "escherichia_coli" in organ and "#1" in organ:
                     organ = organ[:-2]
                 currver = self.db_access.get_version("profile_{}".format(organ))
-                profile_no = re.search(r"\d+", sample[2]).group(0)
+                
+                st_link = entry.find_all("a")[1]["href"]
+                profiles_query = urllib.request.urlopen(st_link)
+                profile_no = profiles_query.readlines()[-1].decode("utf-8").split("\t")[0]
+                #profile_no = re.search(r"\d+", sample[2]).group(0)
                 if (
                     organ in self.organisms
                     and organ.replace("_", " ") not in self.updated
@@ -165,7 +169,7 @@ class Referencer:
                     )
                 ):
                     # Download definition files
-                    st_link = prefix + entry.find_all("a")[1]["href"]
+                    #st_link = prefix + entry.find_all("a")[1]["href"]
                     output = "{}/{}".format(self.config["folders"]["profiles"], organ)
                     urllib.request.urlretrieve(st_link, output)
                     # Update database
@@ -192,6 +196,7 @@ class Referencer:
                     iterator.__next__()
         except StopIteration:
             pass
+
 
     def resync(self, type="", sample="", ignore=False):
         """Manipulates samples that have an internal ST that differs from pubMLST ST"""

--- a/microSALT/utils/referencer.py
+++ b/microSALT/utils/referencer.py
@@ -193,7 +193,6 @@ class Referencer:
         except StopIteration:
             pass
 
-
     def resync(self, type="", sample="", ignore=False):
         """Manipulates samples that have an internal ST that differs from pubMLST ST"""
         if type == "list":

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black
+black==18.5b1
 coverage==4.5.4
 gitlint
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 biopython
 bs4
-click==7.1.2
+click==7.0
 flask
 flask_sqlalchemy
 pymysql

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 biopython
 bs4
-click==7.0
+click==7.1.2
 flask
 flask_sqlalchemy
 pymysql


### PR DESCRIPTION
# Description

The features of this PR primarily concerns internals.

Summary of the changes made:

Due to changes at pubmlst.org; microSALT was unable to gather the version number for external references. This is now resolved.

## Primary function of PR
- [x] Hotfix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

# Testing
_If the update is a hotfix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR._

_Additional testing routine to verify the stability of the PR:_

- _`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-microsalt-stage.sh fix_referencer`_
- _`us`_
- _`source activate S_microSALT`_
- Download/copy the existing profile and loci files for Klebsiella pseudomonas
- cg workflow microsalt config-case ACC6369A43
- microSALT analyse /home/proj/stage/microbial/queries/ACC6369A43.json --input /home/proj/stage/microbial/fastq/ACC6369/ACC6369A43
- Investigate the database file, to see that Klebsiella pseudomonas recieved the correct version number ( sqlite3 microsalt.db . SELECT * FROM versions; .quit )

## Test results
_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

sqlite> SELECT * FROM versions;
profile_klebsiella_pneumoniae|5208

Where 5208 is the latest MLST profile for K. pneumoniae. Also no error messages observed when starting the run.

# Sign-offs
- [x] Code tested by @talnor 
- [x] Approved to run at Clinical-Genomics by @sylvinite
