### PR TITLE
Attempt to make resistance searches more compatible

### DIFF
--- a/microSALT/__init__.py
+++ b/microSALT/__init__.py
@@ -10,7 +10,7 @@ import sys
 from flask import Flask
 from distutils.sysconfig import get_python_lib
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"
 
 app = Flask(__name__, template_folder="server/templates")
 app.config.setdefault("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")

--- a/microSALT/__init__.py
+++ b/microSALT/__init__.py
@@ -10,7 +10,7 @@ import sys
 from flask import Flask
 from distutils.sysconfig import get_python_lib
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 app = Flask(__name__, template_folder="server/templates")
 app.config.setdefault("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")

--- a/microSALT/utils/scraper.py
+++ b/microSALT/utils/scraper.py
@@ -109,6 +109,9 @@ class Scraper:
         """Scrapes a quast report for assembly information"""
         if filename == "":
             filename = "{}/assembly/quast/{}_report.tsv".format(self.sampledir, self.name)
+            if not os.path.isfile(filename):
+                filename = "{}/assembly/quast/report.tsv".format(self.sampledir)
+
         quast = dict()
         try:
             with open(filename, "r") as infile:

--- a/microSALT/utils/scraper.py
+++ b/microSALT/utils/scraper.py
@@ -236,7 +236,11 @@ class Scraper:
                                     padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1]))]
                                     if len(padder) == 0:
                                         padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1][:-1]))]
-                                    padder = padder[0]
+                                    try:
+                                        padder = padder[0]
+                                    except IndexError as e:
+                                        self.logger.warning("In {} gene {} can't be resolved. Wrong resistance?".format(self.name, partials[1]))
+
                                     hypo[-1]["span"] = (
                                         float(hypo[-1]["subject_length"])
                                         / locilengths[padder]
@@ -289,10 +293,13 @@ class Scraper:
                                     hypo[-1]["allele"] = int(partials.group(2))
                                     #Ignores reference name and finds relevant resFinder entry
 
-                                    padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1]))]
+                                    padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[0]))]
                                     if len(padder) == 0:
-                                        padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1][:-1]))]
-                                    padder = padder[0]
+                                        padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[0][:-1]))]                 
+                                    try:
+                                        padder = padder[0]
+                                    except IndexError as e:
+                                        self.logger.warning("In {} allele {} can't be resolved. Wrong organism?".format(self.name, partials[0]))
                                     hypo[-1]["span"] = (
                                         float(hypo[-1]["subject_length"])
                                         / locilengths[padder]

--- a/microSALT/utils/scraper.py
+++ b/microSALT/utils/scraper.py
@@ -217,10 +217,7 @@ class Scraper:
 
                                 if type == "resistance":
                                     hypo[-1]["instance"] = filename
-                                    partials = re.search(
-                                        r"(?:\>)*(.+)_(\d+){1,3}(?:_(.+))",
-                                        elem_list[3],
-                                    )
+                                    partials = re.search("(?:\>)*(.+)_(\d+){1,3}(?:_(.+))",elem_list[3])
                                     hypo[-1]["reference"] = partials.group(3)
                                     hypo[-1]["gene"] = partials.group(1)
                                     if hypo[-1]["gene"] in self.gene2resistance.keys():
@@ -231,9 +228,11 @@ class Scraper:
                                         hypo[-1]["{}".format(type)] = hypo[-1][
                                             "instance"
                                         ].capitalize()
+                                    #Ignores reference name and finds relevant resFinder entry
+                                    padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1]))][0]
                                     hypo[-1]["span"] = (
                                         float(hypo[-1]["subject_length"])
-                                        / locilengths[">{}".format(elem_list[3])]
+                                        / locilengths[padder]
                                     )
 
                                 elif type == "expec":
@@ -269,9 +268,10 @@ class Scraper:
                                         )
                                     else:
                                         hypo[-1]["virulence"] = ""
+                                    padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1]))][0]
                                     hypo[-1]["span"] = (
                                         float(hypo[-1]["subject_length"])
-                                        / locilengths[">{}".format(elem_list[3])]
+                                        / locilengths[padder]
                                     )
 
                                 elif type == "seq_type":
@@ -280,9 +280,10 @@ class Scraper:
                                     )
                                     hypo[-1]["loci"] = partials.group(1)
                                     hypo[-1]["allele"] = int(partials.group(2))
+                                    padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1]))][0]
                                     hypo[-1]["span"] = (
                                         float(hypo[-1]["subject_length"])
-                                        / locilengths[">{}".format(elem_list[3])]
+                                        / locilengths[padder]
                                     )
 
                                 # split elem 2 into contig node_NO, length, cov

--- a/microSALT/utils/scraper.py
+++ b/microSALT/utils/scraper.py
@@ -218,7 +218,7 @@ class Scraper:
                                 if type == "resistance":
                                     hypo[-1]["instance"] = filename
                                     partials = re.search(
-                                        r"(?:\>)*(.+)_(\d+){1,3}(?:_(.+))*",
+                                        r"(?:\>)*(.+)_(\d+){1,3}(?:_(.+))",
                                         elem_list[3],
                                     )
                                     hypo[-1]["reference"] = partials.group(3)

--- a/microSALT/utils/scraper.py
+++ b/microSALT/utils/scraper.py
@@ -229,7 +229,11 @@ class Scraper:
                                             "instance"
                                         ].capitalize()
                                     #Ignores reference name and finds relevant resFinder entry
-                                    padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1]))][0]
+
+                                    padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1]))]
+                                    if len(padder) == 0:
+                                        padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1][:-1]))]
+                                    padder = padder[0]
                                     hypo[-1]["span"] = (
                                         float(hypo[-1]["subject_length"])
                                         / locilengths[padder]
@@ -268,10 +272,10 @@ class Scraper:
                                         )
                                     else:
                                         hypo[-1]["virulence"] = ""
-                                    padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1]))][0]
+                                    #padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1]))][0]
                                     hypo[-1]["span"] = (
                                         float(hypo[-1]["subject_length"])
-                                        / locilengths[padder]
+                                        / locilengths[">{}".format(elem_list[3])]
                                     )
 
                                 elif type == "seq_type":
@@ -280,7 +284,12 @@ class Scraper:
                                     )
                                     hypo[-1]["loci"] = partials.group(1)
                                     hypo[-1]["allele"] = int(partials.group(2))
-                                    padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1]))][0]
+                                    #Ignores reference name and finds relevant resFinder entry
+
+                                    padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1]))]
+                                    if len(padder) == 0:
+                                        padder = [x for x in locilengths.keys() if x.startswith('>{}'.format(partials[1][:-1]))]
+                                    padder = padder[0]
                                     hypo[-1]["span"] = (
                                         float(hypo[-1]["subject_length"])
                                         / locilengths[padder]
@@ -293,7 +302,7 @@ class Scraper:
                                 )
                                 hypo[-1]["contig_length"] = int(nodeinfo[3])
                                 hypo[-1]["contig_coverage"] = nodeinfo[5]
-                                self.logger.debug("scrape_blast scrape loop hit")
+                                self.logger.debug("scrape_blast scrape loop hit '{}'".format(elem_list[3]))
             self.logger.info("{} candidate {} hits found".format(len(hypo), type2db))
         except Exception as e:
             self.logger.error("Unable to process the pattern of {}".format(str(e)))


### PR DESCRIPTION
# Description

_The features of this PR primarily concerns internals_

_Summary of the changes made:_
* Improved backwards compatibility for QUAST files and old resFinder resistance reference files.

This improvement was made in order to re-run ALL old analysis.

## Primary function of PR
- [ ] Hotfix
- [x] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

# Testing
Tests are self-evident as the fix was used to successfully re-run all old data.

# Sign-offs
- [x] Code tested by @sylvinite
- [x] Approved to run at Clinical-Genomics by @sylvinite
