### PR TITLE
specify openjdk version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,7 @@ conda install -y samtools=1.13
 conda install -y spades=3.13.1
 conda install -y trimmomatic=0.39
 conda install -y r-base=4.1.1
+conda install -y openjdk=11.0.9.1
 
 if [[ $type == "release" ]]; then
     pip install -r https://raw.githubusercontent.com/Clinical-Genomics/microSALT/$branch/requirements.txt -r https://raw.githubusercontent.com/Clinical-Genomics/microSALT/$branch/requirements-dev.txt 


### PR DESCRIPTION
This PR specifies a version of openjdk in the install script which would enable trimmomatic to run without the random fails mentioned in this issue: https://github.com/Clinical-Genomics/microSALT/issues/152