### PR TITLE
fix(SWEDAC) SWEDAC logo only on MW samples

### DIFF
--- a/microSALT/server/templates/alignment_page.html
+++ b/microSALT/server/templates/alignment_page.html
@@ -10,7 +10,9 @@
               <img src="https://github.com/Clinical-Genomics/microSALT/blob/master/artwork/microsalt.jpg?raw=true" \
               alt="MicroSALT Logo" align="left" \
               style="position:absolute;left:15px;width:400px;height:100px;display:flex;"></a>
-              <img src="https://github.com/Clinical-Genomics/microSALT/blob/master/artwork/swedac.jpg?raw=true" alt="Swedac Logo" align="right" style="display:flex;">
+              {% if 'MW' in topsample.application_tag %}
+                <img src="https://github.com/Clinical-Genomics/microSALT/blob/master/artwork/swedac.jpg?raw=true" alt="Swedac Logo" align="right" style="display:flex;">
+              {% endif %}
               <h2 class="page-header">
                 <small><br><br><br>Kvalitetskontrollsrapport</small>
 

--- a/microSALT/server/templates/typing_page.html
+++ b/microSALT/server/templates/typing_page.html
@@ -10,7 +10,9 @@
               <img src="https://github.com/Clinical-Genomics/microSALT/blob/master/artwork/microsalt.jpg?raw=true" \
               alt="MicroSALT Logo" align="left" \
               style="position:absolute;left:15px;width:400px;height:100px;display:flex;"></a>
-              <img src="https://github.com/Clinical-Genomics/microSALT/blob/master/artwork/swedac.jpg?raw=true" alt="Swedac Logo" align="right" style="display:flex;">
+              {% if 'MW' in topsample.application_tag %}
+                <img src="https://github.com/Clinical-Genomics/microSALT/blob/master/artwork/swedac.jpg?raw=true" alt="Swedac Logo" align="right" style="display:flex;">
+              {% endif %}
               <h2 class="page-header">
                 <small><br><br><br>Typningsrapport</small>
               <small><p align="center">Rapport genererad: {{date}}</p></small></h2>


### PR DESCRIPTION
# Description
Implements a commit from #125 to remove swedac logo for non-accredited analyses.

## Primary function of PR
- [ ] Hotfix
- [x] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

## Test results
_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._
See comments
# Sign-offs
- [x] Code tested by VJ
- [x] Approved to run at Clinical-Genomics by HS
