### PR TITLE
Fix #185: Add back more greedy elimination of similar results

### DIFF
--- a/microSALT/utils/scraper.py
+++ b/microSALT/utils/scraper.py
@@ -391,7 +391,7 @@ class Scraper:
                         # Identical identity and span, seperating based on contig coverage
                         else:
                             # Rightmost is worse
-                            if float(hypo[ind].get("contig_coverage")) > float(
+                            if float(hypo[ind].get("contig_coverage")) >= float(
                                 hypo[targ].get("contig_coverage")
                             ):
                                 del hypo[targ]


### PR DESCRIPTION
# Description

This PR fixes issue #185 , which through testing has been shown to be due to a combination of factors:

1. The introduction, in february 2023, in the ResFinder database of an ["all" file (`all.fsa`)](https://bitbucket.org/genomicepidemiology/resfinder_db/src/master/all.fsa) in combination with the other files with resistance genes, meaning the genes are duplicated in the ResFinder database.
2. The fact that we changed a comparison method in microSALT for the microSALT release that would earlier remove also identical duplicates, but which does no longer do that (see the change [here](https://github.com/Clinical-Genomics/microSALT/commit/edb92569491ed8a9c5e7a75f16f6e9a0e0f549f9#diff-79fdcbc666e5174e549ad4bbaab91c2cb894478346827f3b624e82fa719a8426L394)).

The effect of the change in 2. above was missed since the ResFinder database in the stage environment was not updated and thus there were no duplicates during testing. But when the updated microSALT runs in production, it contains duplicated sequences which are no longer filtered out.

_Summary of the changes made:_

This fix simply rolls back the comparison method that can filter out also identical duplicates.

## Primary function of PR
- [x] Hotfix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

# Testing

_If the update is a hotfix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR._

The fix has been tested on a case where the customer reported duplicated rows (adaptedstarfish).

## Test results
_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

1. First, we tested running the case in the stage environment, and did not get duplicated rows.

For the ...A26 sample, this is how the resistances looked then (no duplicates):

![image](https://github.com/user-attachments/assets/3db89a8b-136a-4536-a157-a3f22447ddcc)

2. We then copied over the `all.fsa` file and accompanying `all.*` files from the production environment. Now the duplicated rows showed up.

Now, the resistances look like this (duplicates):

![image](https://github.com/user-attachments/assets/d02b2180-5fca-4282-871a-aca51b669225)

3. Then, we applied the fix in this PR, and the duplicated rows were removed again.

The resistances are now removed:

![image](https://github.com/user-attachments/assets/7a8ac68c-93c9-4d31-ac85-140dcf01ec27)


# Sign-offs
- [ ] Code tested by @octocat
- [x] Approved to run at Clinical-Genomics by @karlnyr 
