### PR TITLE
Fix-pubmlst-query-insert

### DIFF
--- a/microSALT/store/models.py
+++ b/microSALT/store/models.py
@@ -19,33 +19,23 @@ class Profiles:
                 self.add_table(file)
         except Exception as e:
             self.logger.error(
-                "Unable to open profile folder {}".format(
-                    self.config["folders"]["profiles"]
-                )
+                "Unable to open profile folder {}".format(self.config["folders"]["profiles"])
             )
 
     def add_table(self, file):
         try:
-            with open(
-                "{}/{}".format(self.config["folders"]["profiles"], file), "r"
-            ) as fh:
+            with open("{}/{}".format(self.config["folders"]["profiles"], file), "r") as fh:
                 # Sets profile_* headers
                 head = fh.readline()
-                head = head.rstrip().split("\t")
+                head = head.rstrip().split("\t")[:8]  # Only consider the first 8 elements
                 index = 0
 
                 header = "Table('profile_{}'.format(file), self.metadata,".format(file)
                 while index < len(head):
                     # Set ST as PK
                     if head[index] == "ST":
-                        header += "Column(head[{}], SmallInteger, primary_key=True),".format(
-                            index
-                        )
-                    # Set Clonal complex as string
-                    elif head[index] == "clonal_complex" or head[index] == "species":
-                        header += "Column(head[{}], String(40)),".format(index)
-                    else:
-                        header += "Column(head[{}], SmallInteger),".format(index)
+                        header += "Column(head[{}], SmallInteger, primary_key=True),".format(index)
+                    header += "Column(head[{}], SmallInteger),".format(index)
                     index = index + 1
                 header += ")"
                 p = eval(header)
@@ -66,33 +56,24 @@ class Novel:
                 self.add_table(file)
         except Exception as e:
             self.logger.error(
-                "Unable to open profile folder {}".format(
-                    self.config["folders"]["profiles"]
-                )
+                "Unable to open profile folder {}".format(self.config["folders"]["profiles"])
             )
 
     def add_table(self, file):
         try:
-            with open(
-                "{}/{}".format(self.config["folders"]["profiles"], file), "r"
-            ) as fh:
+            with open("{}/{}".format(self.config["folders"]["profiles"], file), "r") as fh:
                 # Sets profile_* headers
                 head = fh.readline()
-                head = head.rstrip().split("\t")
+                head = head.rstrip().split("\t")[:8]  # Only consider the first 8 elements
                 index = 0
 
                 header = "Table('novel_{}'.format(file), self.metadata,".format(file)
                 while index < len(head):
                     # Set ST as PK
                     if head[index] == "ST":
-                        header += "Column(head[{}], SmallInteger, primary_key=True),".format(
-                            index
-                        )
+                        header += "Column(head[{}], SmallInteger, primary_key=True),".format(index)
                     # Set Clonal complex as string
-                    elif head[index] == "clonal_complex" or head[index] == "species":
-                        header += "Column(head[{}], String(40)),".format(index)
-                    else:
-                        header += "Column(head[{}], SmallInteger),".format(index)
+                    header += "Column(head[{}], SmallInteger),".format(index)
                     index = index + 1
                 header += ")"
                 p = eval(header)

--- a/microSALT/store/models.py
+++ b/microSALT/store/models.py
@@ -35,7 +35,8 @@ class Profiles:
                     # Set ST as PK
                     if head[index] == "ST":
                         header += "Column(head[{}], SmallInteger, primary_key=True),".format(index)
-                    header += "Column(head[{}], SmallInteger),".format(index)
+                    else:
+                        header += "Column(head[{}], SmallInteger),".format(index)
                     index = index + 1
                 header += ")"
                 p = eval(header)
@@ -73,7 +74,8 @@ class Novel:
                     if head[index] == "ST":
                         header += "Column(head[{}], SmallInteger, primary_key=True),".format(index)
                     # Set Clonal complex as string
-                    header += "Column(head[{}], SmallInteger),".format(index)
+                    else:
+                        header += "Column(head[{}], SmallInteger),".format(index)
                     index = index + 1
                 header += ")"
                 p = eval(header)

--- a/microSALT/utils/referencer.py
+++ b/microSALT/utils/referencer.py
@@ -46,9 +46,8 @@ class Referencer:
             self.sample = self.sampleinfo
         self.client = PubMLSTClient()
 
-
     def identify_new(self, cg_id="", project=False):
-        """ Automatically downloads pubMLST & NCBI organisms not already downloaded """
+        """Automatically downloads pubMLST & NCBI organisms not already downloaded"""
         neworgs = list()
         newrefs = list()
         try:
@@ -91,9 +90,7 @@ class Referencer:
         """Check for indexation, makeblastdb job if not enough of them."""
         reindexation = False
         files = os.listdir(full_dir)
-        sufx_files = glob.glob(
-            "{}/*{}".format(full_dir, suffix)
-        )  # List of source files
+        sufx_files = glob.glob("{}/*{}".format(full_dir, suffix))  # List of source files
         for file in sufx_files:
             subsuf = "\{}$".format(suffix)
             base = re.sub(subsuf, "", file)
@@ -105,10 +102,7 @@ class Referencer:
                 if os.path.basename(base) == elem[: elem.rfind(".")]:
                     bases = bases + 1
                     # Number of index files fresher than source (6)
-                    if (
-                        os.stat(file).st_mtime
-                        < os.stat("{}/{}".format(full_dir, elem)).st_mtime
-                    ):
+                    if os.stat(file).st_mtime < os.stat("{}/{}".format(full_dir, elem)).st_mtime:
                         newer = newer + 1
             # 7 for parse_seqids, 4 for not.
             if not (bases == 7 or newer == 6) and not (bases == 4 and newer == 3):
@@ -121,18 +115,16 @@ class Referencer:
                         )
                     # MLST locis
                     else:
-                        bash_cmd = "makeblastdb -in {}/{} -dbtype nucl -parse_seqids -out {}".format(
-                            full_dir, os.path.basename(file), os.path.basename(base)
+                        bash_cmd = (
+                            "makeblastdb -in {}/{} -dbtype nucl -parse_seqids -out {}".format(
+                                full_dir, os.path.basename(file), os.path.basename(base)
+                            )
                         )
-                    proc = subprocess.Popen(
-                        bash_cmd.split(), cwd=full_dir, stdout=subprocess.PIPE
-                    )
+                    proc = subprocess.Popen(bash_cmd.split(), cwd=full_dir, stdout=subprocess.PIPE)
                     proc.communicate()
                 except Exception as e:
                     self.logger.error(
-                        "Unable to index requested target {} in {}".format(
-                            file, full_dir
-                        )
+                        "Unable to index requested target {} in {}".format(file, full_dir)
                     )
         if reindexation:
             self.logger.info("Re-indexed contents of {}".format(full_dir))
@@ -145,7 +137,7 @@ class Referencer:
             for entry in root:
                 # Check organism
                 species = entry.text.strip()
-                organ = species.lower().replace(" ", "_") 
+                organ = species.lower().replace(" ", "_")
                 if "escherichia_coli" in organ and "#1" in organ:
                     organ = organ[:-2]
                 if organ in self.organisms:
@@ -154,15 +146,11 @@ class Referencer:
                     st_link = entry.find("./mlst/database/profiles/url").text
                     profiles_query = urllib.request.urlopen(st_link)
                     profile_no = profiles_query.readlines()[-1].decode("utf-8").split("\t")[0]
-                    if (
-                        organ.replace("_", " ") not in self.updated
-                        and (
-                            int(profile_no.replace("-", "")) > int(currver.replace("-", ""))
-                            or force
-                        )
+                    if organ.replace("_", " ") not in self.updated and (
+                        int(profile_no.replace("-", "")) > int(currver.replace("-", "")) or force
                     ):
                         # Download MLST profiles
-                        self.logger.info("Downloading new MLST profiles for " + species)       
+                        self.logger.info("Downloading new MLST profiles for " + species)
                         output = "{}/{}".format(self.config["folders"]["profiles"], organ)
                         urllib.request.urlretrieve(st_link, output)
                         # Clear existing directory and download allele files
@@ -172,7 +160,9 @@ class Referencer:
                         for locus in entry.findall("./mlst/database/loci/locus"):
                             locus_name = locus.text.strip()
                             locus_link = locus.find("./url").text
-                            urllib.request.urlretrieve(locus_link, "{}/{}.tfa".format(out, locus_name))
+                            urllib.request.urlretrieve(
+                                locus_link, "{}/{}.tfa".format(out, locus_name)
+                            )
                         # Create new indexes
                         self.index_db(out, ".tfa")
                         # Update database
@@ -183,9 +173,7 @@ class Referencer:
                         )
                         self.db_access.reload_profiletable(organ)
         except Exception as e:
-            self.logger.warning(
-                "Unable to update pubMLST external data: {}".format(e)
-            )
+            self.logger.warning("Unable to update pubMLST external data: {}".format(e))
 
     def resync(self, type="", sample="", ignore=False):
         """Manipulates samples that have an internal ST that differs from pubMLST ST"""
@@ -228,9 +216,7 @@ class Referencer:
 
                 for file in os.listdir(hiddensrc):
                     if file not in actual and (".fsa" in file):
-                        self.logger.info(
-                            "resFinder database files corrupted. Syncing..."
-                        )
+                        self.logger.info("resFinder database files corrupted. Syncing...")
                         wipeIndex = True
                         break
 
@@ -262,12 +248,12 @@ class Referencer:
         self.index_db(self.config["folders"]["resistances"], ".fsa")
 
     def existing_organisms(self):
-        """ Returns list of all organisms currently added """
+        """Returns list of all organisms currently added"""
         return self.organisms
 
     def organism2reference(self, normal_organism_name):
         """Finds which reference contains the same words as the organism
-       and returns it in a format for database calls. Returns empty string if none found"""
+        and returns it in a format for database calls. Returns empty string if none found"""
         orgs = os.listdir(self.config["folders"]["references"])
         organism = re.split(r"\W+", normal_organism_name.lower())
         try:
@@ -296,13 +282,11 @@ class Referencer:
             )
 
     def download_ncbi(self, reference):
-        """ Checks available references, downloads from NCBI if not present """
+        """Checks available references, downloads from NCBI if not present"""
         try:
             DEVNULL = open(os.devnull, "wb")
             Entrez.email = "2@2.com"
-            record = Entrez.efetch(
-                db="nucleotide", id=reference, rettype="fasta", retmod="text"
-            )
+            record = Entrez.efetch(db="nucleotide", id=reference, rettype="fasta", retmod="text")
             sequence = record.read()
             output = "{}/{}.fasta".format(self.config["folders"]["genomes"], reference)
             with open(output, "w") as f:
@@ -325,20 +309,16 @@ class Referencer:
             out, err = proc.communicate()
             self.logger.info("Downloaded reference {}".format(reference))
         except Exception as e:
-            self.logger.warning(
-                "Unable to download genome '{}' from NCBI".format(reference)
-            )
+            self.logger.warning("Unable to download genome '{}' from NCBI".format(reference))
 
     def add_pubmlst(self, organism):
-        """ Checks pubmlst for references of given organism and downloads them """
+        """Checks pubmlst for references of given organism and downloads them"""
         # Organism must be in binomial format and only resolve to one hit
         errorg = organism
         try:
             organism = organism.lower().replace(".", " ")
             if organism.replace(" ", "_") in self.organisms and not self.force:
-                self.logger.info(
-                    "Organism {} already stored in microSALT".format(organism)
-                )
+                self.logger.info("Organism {} already stored in microSALT".format(organism))
                 return
             db_query = self.query_pubmlst()
 
@@ -360,9 +340,7 @@ class Referencer:
                         seqdef_url = subtype["href"]
                         desc = subtype["description"]
                         counter += 1.0
-                        self.logger.info(
-                            "Located pubMLST hit {} for sample".format(desc)
-                        )
+                        self.logger.info("Located pubMLST hit {} for sample".format(desc))
             if counter > 2.0:
                 raise Exception(
                     "Reference '{}' resolved to {} organisms. Please be more stringent".format(
@@ -372,9 +350,7 @@ class Referencer:
             elif counter < 1.0:
                 # add external
                 raise Exception(
-                    "Unable to find requested organism '{}' in pubMLST database".format(
-                        errorg
-                    )
+                    "Unable to find requested organism '{}' in pubMLST database".format(errorg)
                 )
             else:
                 truename = desc.lower().split(" ")
@@ -387,16 +363,15 @@ class Referencer:
             self.logger.warning(e.args[0])
 
     def query_pubmlst(self):
-        """ Returns a json object containing all organisms available via pubmlst.org """
+        """Returns a json object containing all organisms available via pubmlst.org"""
         db_query = self.client.query_databases()
         return db_query
 
-
     def get_mlst_scheme(self, subtype_href):
-        """ Returns the path for the MLST data scheme at pubMLST """
+        """Returns the path for the MLST data scheme at pubMLST"""
         try:
             parsed_data = self.client.parse_pubmlst_url(subtype_href)
-            db = parsed_data.get('db')
+            db = parsed_data.get("db")
             if not db:
                 self.logger.warning(f"Could not extract database name from URL: {subtype_href}")
                 return None
@@ -424,9 +399,8 @@ class Referencer:
             self.logger.warning(e)
             return None
 
-
     def external_version(self, organism, subtype_href):
-        """ Returns the version (date) of the data available on pubMLST """
+        """Returns the version (date) of the data available on pubMLST"""
         try:
             mlst_href = self.get_mlst_scheme(subtype_href)
             if not mlst_href:
@@ -434,39 +408,42 @@ class Referencer:
                 return None
 
             parsed_data = self.client.parse_pubmlst_url(mlst_href)
-            db = parsed_data.get('db')
-            scheme_id = parsed_data.get('scheme_id')
+            db = parsed_data.get("db")
+            scheme_id = parsed_data.get("scheme_id")
             if not db or not scheme_id:
-                self.logger.warning(f"Could not extract database name or scheme ID from MLST URL: {mlst_href}")
+                self.logger.warning(
+                    f"Could not extract database name or scheme ID from MLST URL: {mlst_href}"
+                )
                 return None
 
             scheme_info = self.client.retrieve_scheme_info(db, scheme_id)
             last_updated = scheme_info.get("last_updated")
             if last_updated:
-                self.logger.debug(f"Retrieved last_updated: {last_updated} for organism: {organism}")
+                self.logger.debug(
+                    f"Retrieved last_updated: {last_updated} for organism: {organism}"
+                )
                 return last_updated
             else:
-                self.logger.warning(f"No 'last_updated' field found for db: {db}, scheme_id: {scheme_id}")
+                self.logger.warning(
+                    f"No 'last_updated' field found for db: {db}, scheme_id: {scheme_id}"
+                )
                 return None
         except Exception as e:
             self.logger.warning(f"Could not determine pubMLST version for {organism}")
             self.logger.warning(e)
             return None
 
-
     def download_pubmlst(self, organism, subtype_href, force=False):
-        """ Downloads ST and loci for a given organism stored on pubMLST if it is more recent. Returns update date """
+        """Downloads ST and loci for a given organism stored on pubMLST if it is more recent. Returns update date"""
         organism = organism.lower().replace(" ", "_")
         try:
             # Pull version
             extver = self.external_version(organism, subtype_href)
             currver = self.db_access.get_version(f"profile_{organism}")
-            if (
-                int(extver.replace("-", ""))
-                <= int(currver.replace("-", ""))
-                and not force
-            ):
-                self.logger.info(f"Profile for {organism.replace('_', ' ').capitalize()} already at the latest version.")
+            if int(extver.replace("-", "")) <= int(currver.replace("-", "")) and not force:
+                self.logger.info(
+                    f"Profile for {organism.replace('_', ' ').capitalize()} already at the latest version."
+                )
                 return currver
 
             # Retrieve the MLST scheme URL
@@ -477,10 +454,12 @@ class Referencer:
 
             # Parse the database name and scheme ID
             parsed_data = self.client.parse_pubmlst_url(mlst_href)
-            db = parsed_data.get('db')
-            scheme_id = parsed_data.get('scheme_id')
+            db = parsed_data.get("db")
+            scheme_id = parsed_data.get("scheme_id")
             if not db or not scheme_id:
-                self.logger.warning(f"Could not extract database name or scheme ID from MLST URL: {mlst_href}")
+                self.logger.warning(
+                    f"Could not extract database name or scheme ID from MLST URL: {mlst_href}"
+                )
                 return None
 
             # Step 1: Download the profiles CSV
@@ -488,7 +467,12 @@ class Referencer:
             profiles_csv = self.client.download_profiles_csv(db, scheme_id)
             # Only write the first 8 columns, this avoids adding information such as "clonal_complex" and "species"
             profiles_csv = profiles_csv.split("\n")
-            profiles_csv = "\n".join("\t".join([line.split("\t")[:8] for line in profiles_csv]))
+            trimmed_profiles = []
+            for line in profiles_csv:
+                trimmed_profiles.append("\t".join(line.split("\t")[:8]))
+
+            profiles_csv = "\n".join(trimmed_profiles)
+
             with open(st_target, "w") as profile_file:
                 profile_file.write(profiles_csv)
             self.logger.info(f"Profiles CSV downloaded to {st_target}")
@@ -518,9 +502,8 @@ class Referencer:
             self.logger.error(f"Failed to download data for {organism}: {e}")
             return None
 
-
     def fetch_pubmlst(self, force=False):
-        """ Updates reference for data that is stored on pubMLST """
+        """Updates reference for data that is stored on pubMLST"""
         seqdef_url = dict()
         db_query = self.query_pubmlst()
 

--- a/microSALT/utils/referencer.py
+++ b/microSALT/utils/referencer.py
@@ -488,7 +488,7 @@ class Referencer:
             profiles_csv = self.client.download_profiles_csv(db, scheme_id)
             # Only write the first 8 columns, this avoids adding information such as "clonal_complex" and "species"
             profiles_csv = profiles_csv.split("\n")
-            profiles_csv = "\n".join([line.split(",")[:8] for line in profiles_csv])
+            profiles_csv = "\n".join("\t".join([line.split("\t")[:8] for line in profiles_csv]))
             with open(st_target, "w") as profile_file:
                 profile_file.write(profiles_csv)
             self.logger.info(f"Profiles CSV downloaded to {st_target}")

--- a/microSALT/utils/referencer.py
+++ b/microSALT/utils/referencer.py
@@ -486,6 +486,9 @@ class Referencer:
             # Step 1: Download the profiles CSV
             st_target = f"{self.config['folders']['profiles']}/{organism}"
             profiles_csv = self.client.download_profiles_csv(db, scheme_id)
+            # Only write the first 8 columns, this avoids adding information such as "clonal_complex" and "species"
+            profiles_csv = profiles_csv.split("\n")
+            profiles_csv = "\n".join([line.split(",")[:8] for line in profiles_csv])
             with open(st_target, "w") as profile_file:
                 profile_file.write(profiles_csv)
             self.logger.info(f"Profiles CSV downloaded to {st_target}")


### PR DESCRIPTION
# Description

This PR tries to adress the issue that when we download databases and try to update existing ones we have the clonal complex and species column. Two columns that are not used in the analysis.

### Code Formatting Improvements:

* [`microSALT/store/models.py`](diffhunk://#diff-2aa8f114d897cc9e9ea718c9c3f23ed8177e35c319b4bf19c1a81b4c96b3d5caL22-R37): Simplified the formatting of error messages and file handling to improve readability. [[1]](diffhunk://#diff-2aa8f114d897cc9e9ea718c9c3f23ed8177e35c319b4bf19c1a81b4c96b3d5caL22-R37) [[2]](diffhunk://#diff-2aa8f114d897cc9e9ea718c9c3f23ed8177e35c319b4bf19c1a81b4c96b3d5caL69-L93)

### Minor Logic Adjustments:

* [`microSALT/store/models.py`](diffhunk://#diff-2aa8f114d897cc9e9ea718c9c3f23ed8177e35c319b4bf19c1a81b4c96b3d5caL22-R37): Limited the number of elements considered in the header to the first 8 elements to avoid unnecessary processing. [[1]](diffhunk://#diff-2aa8f114d897cc9e9ea718c9c3f23ed8177e35c319b4bf19c1a81b4c96b3d5caL22-R37) [[2]](diffhunk://#diff-2aa8f114d897cc9e9ea718c9c3f23ed8177e35c319b4bf19c1a81b4c96b3d5caL69-L93)

* [`microSALT/utils/referencer.py`](diffhunk://#diff-8ed61a0d3f932c398f15d06de2faa44abecb46379f31abff243ec61143fcbe51L480-R475): Added logic to only write the first 8 columns of the profiles CSV to avoid adding unnecessary information such as "clonal_complex" and "species".


## Primary function of PR
- [ ] Hotfix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

# Testing
_If the update is a hotfix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR._

_Test routine to verify the stability of the PR:_
- _`bash /home/proj/production/servers/resources/hasta.scilifelab.se/install-microsalt-stage.sh BRANCHNAME`_
- _`us`_
- _`conda activate S_microSALT`_
- _(SITUATIONAL) `export MICROSALT_CONFIG=/home/proj/dropbox/microSALT.json`_
- _Select a relevant subset of the following:_
- _`microSALT analyse project MIC3109`_
- _`microSALT analyse project MIC4107`_
- _`microSALT analyse project MIC4109`_
- _`microSALT analyse project ACC5551`_

_Verify that the results for projects MIC3109, MIC4107, MIC4109 & ACC5551 are consistent with the results attached to AMSystem doc 1490, Microbial_WGS.xlsx_

## Test results
_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

# Sign-offs
- [ ] Code tested by @octocat
- [ ] Approved to run at Clinical-Genomics by @karlnyr 
