### PR TITLE
feat: add support for new application tag in microbial sequencing descriptions

### DIFF
--- a/microSALT/server/templates/alignment_page.html
+++ b/microSALT/server/templates/alignment_page.html
@@ -219,7 +219,7 @@
               {% if topsample.application_tag == "MWRNXTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
               Nextera library preparation.
-              {% if topsample.application_tag == "NEW_APP_TAG" %}
+              {% if topsample.application_tag == "MWSDPTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
               Microbial library preparation (based on Illumina Covidseq Kit).
               {% elif topsample.application_tag in ["MWGNXTR003", "MWMNXTR003", "MWLNXTR003"] %}

--- a/microSALT/server/templates/alignment_page.html
+++ b/microSALT/server/templates/alignment_page.html
@@ -221,10 +221,10 @@
               Nextera library preparation.
               {% elif topsample.application_tag == "MWSDPTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
-              Microbial library preparation (based on Illumina Covidseq Kit).
+              Microbial library preparation (baserat p&aring; Illumina COVIDseq Kit).
               {% elif topsample.application_tag == "VWSDPTR001" %}
               Virologisk helgenomssekvensering, med krav p&aring; minst 1 miljon l&auml;spar.
-              Microbial library preparation (based on Illumina Covidseq Kit).
+              Microbial library preparation (baserat p&aring; Illumina COVIDseq Kit).
               {% elif topsample.application_tag in ["MWGNXTR003", "MWMNXTR003", "MWLNXTR003"] %}
               Mikrobiell helgenomssekvensering, med krav p&aring; minst 3 miljoner l&auml;spar.
               Nextera library preparation.

--- a/microSALT/server/templates/alignment_page.html
+++ b/microSALT/server/templates/alignment_page.html
@@ -219,6 +219,9 @@
               {% if topsample.application_tag == "MWRNXTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
               Nextera library preparation.
+              {% if topsample.application_tag == "NEW_APP_TAG" %}
+              Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
+              Microbial library preparation (based on Illumina Covidseq Kit).
               {% elif topsample.application_tag in ["MWGNXTR003", "MWMNXTR003", "MWLNXTR003"] %}
               Mikrobiell helgenomssekvensering, med krav p&aring; minst 3 miljoner l&auml;spar.
               Nextera library preparation.

--- a/microSALT/server/templates/alignment_page.html
+++ b/microSALT/server/templates/alignment_page.html
@@ -219,8 +219,11 @@
               {% if topsample.application_tag == "MWRNXTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
               Nextera library preparation.
-              {% if topsample.application_tag == "MWSDPTR003" %}
+              {% elif topsample.application_tag == "MWSDPTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
+              Microbial library preparation (based on Illumina Covidseq Kit).
+              {% elif topsample.application_tag == "VWSDPTR001" %}
+              Virologisk helgenomssekvensering, med krav p&aring; minst 1 miljon l&auml;spar.
               Microbial library preparation (based on Illumina Covidseq Kit).
               {% elif topsample.application_tag in ["MWGNXTR003", "MWMNXTR003", "MWLNXTR003"] %}
               Mikrobiell helgenomssekvensering, med krav p&aring; minst 3 miljoner l&auml;spar.

--- a/microSALT/server/templates/typing_page.html
+++ b/microSALT/server/templates/typing_page.html
@@ -192,10 +192,10 @@
               Nextera library preparation.
               {% elif topsample.application_tag == "MWSDPTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
-              Microbial library preparation (based on Illumina Covidseq Kit).
+              Microbial library preparation (baserat p&aring; Illumina COVIDseq Kit).
               {% elif topsample.application_tag == "VWSDPTR001" %}
               Virologisk helgenomssekvensering, med krav p&aring; minst 1 miljon l&auml;spar.
-              Microbial library preparation (based on Illumina Covidseq Kit).
+              Microbial library preparation (baserat p&aring; Illumina COVIDseq Kit).
               {% elif topsample.application_tag in ["MWGNXTR003", "MWMNXTR003", "MWLNXTR003"] %}
               Mikrobiell helgenomssekvensering, med krav p&aring; minst 3 miljoner l&auml;spar.
               Nextera library preparation.

--- a/microSALT/server/templates/typing_page.html
+++ b/microSALT/server/templates/typing_page.html
@@ -190,8 +190,11 @@
               {% if topsample.application_tag == "MWRNXTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
               Nextera library preparation.
-              {% if topsample.application_tag == "MWSDPTR003" %}
+              {% elif topsample.application_tag == "MWSDPTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
+              Microbial library preparation (based on Illumina Covidseq Kit).
+              {% elif topsample.application_tag == "VWSDPTR001" %}
+              Virologisk helgenomssekvensering, med krav p&aring; minst 1 miljon l&auml;spar.
               Microbial library preparation (based on Illumina Covidseq Kit).
               {% elif topsample.application_tag in ["MWGNXTR003", "MWMNXTR003", "MWLNXTR003"] %}
               Mikrobiell helgenomssekvensering, med krav p&aring; minst 3 miljoner l&auml;spar.

--- a/microSALT/server/templates/typing_page.html
+++ b/microSALT/server/templates/typing_page.html
@@ -190,7 +190,7 @@
               {% if topsample.application_tag == "MWRNXTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
               Nextera library preparation.
-              {% if topsample.application_tag == "NEW_APP_TAG" %}
+              {% if topsample.application_tag == "MWSDPTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
               Microbial library preparation (based on Illumina Covidseq Kit).
               {% elif topsample.application_tag in ["MWGNXTR003", "MWMNXTR003", "MWLNXTR003"] %}

--- a/microSALT/server/templates/typing_page.html
+++ b/microSALT/server/templates/typing_page.html
@@ -190,6 +190,9 @@
               {% if topsample.application_tag == "MWRNXTR003" %}
               Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
               Nextera library preparation.
+              {% if topsample.application_tag == "NEW_APP_TAG" %}
+              Mikrobiell helgenomssekvensering av rutinprov, med krav p&aring; minst 3 miljoner l&auml;spar.
+              Microbial library preparation (based on Illumina Covidseq Kit).
               {% elif topsample.application_tag in ["MWGNXTR003", "MWMNXTR003", "MWLNXTR003"] %}
               Mikrobiell helgenomssekvensering, med krav p&aring; minst 3 miljoner l&auml;spar.
               Nextera library preparation.


### PR DESCRIPTION
# Description

## Added

- Support for new application tag used for the Illumina Covidseq Kit

## Primary function of PR
- [ ] Hotfix
- [x] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

# Testing
_If the update is a hotfix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR._

_Test routine to verify the stability of the PR:_
- _`bash /home/proj/production/servers/resources/hasta.scilifelab.se/install-microsalt-stage.sh BRANCHNAME`_
- _`us`_
- _`conda activate S_microSALT`_
- _(SITUATIONAL) `export MICROSALT_CONFIG=/home/proj/dropbox/microSALT.json`_
- _Select a relevant subset of the following:_
- _`microSALT analyse project MIC3109`_
- _`microSALT analyse project MIC4107`_
- _`microSALT analyse project MIC4109`_
- _`microSALT analyse project ACC5551`_

_Verify that the results for projects MIC3109, MIC4107, MIC4109 & ACC5551 are consistent with the results attached to AMSystem doc 1490, Microbial_WGS.xlsx_

## Test results
_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

# Sign-offs
- [x] Code tested by @octocat
- [x] Approved to run at Clinical-Genomics by @karlnyr 
