### PR TITLE
fix(input argument to input option)

### DIFF
--- a/microSALT/utils/job_creator.py
+++ b/microSALT/utils/job_creator.py
@@ -700,7 +700,7 @@ class Job_Creator:
             conda_cmd = (
                 f"conda run -p {os.environ['CONDA_PREFIX']} "
                 f"microSALT utils finish {self.finishdir}/sampleinfo.json "
-                f"-input {self.finishdir} "
+                f"--input {self.finishdir} "
                 f"--email {self.config['regex']['mail_recipient']} "
                 f"--report {report} "
                 f"{custom_conf}\n"


### PR DESCRIPTION
## Description

This was a small bug introduced with 4.2.2. Unfortuntately the tests did not discover it, but it causes the mailjob to fail because it is passed as an argument instead of an option.

### Primary function of PR

- [x] Hot-fix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

## Testing

<!-- If the update is a hot-fix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR. -->

- `bash /home/proj/production/servers/resources/hasta.scilifelab.se/install-microsalt-stage.sh BRANCHNAME`
- `us`
- `conda activate S_microSALT`
- `microSALT analyse --input /path/to/fastq/ SAMPLEINFO_FILE`

### Test results

_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

## Sign-offs

- [x] Approved to run at Clinical-Genomics by @karlnyr or @Clinical-Genomics/micro
