### PR TITLE
add email option before email address

### DIFF
--- a/microSALT/utils/job_creator.py
+++ b/microSALT/utils/job_creator.py
@@ -743,7 +743,7 @@ class Job_Creator:
             f"-J {self.config['slurm_header']['job_prefix']}_{self.name}_MAILJOB "
             f"--qos {self.config['slurm_header']['qos']} --open-mode append "
             f"--dependency=afterany:{final} --output {self.config['folders']['log_file']} "
-            f"{self.config['regex']['mail_recipient']}"
+            f"--email {self.config['regex']['mail_recipient']}"
         )
         bash_cmd = "sbatch {} {}".format(head, mailfile)
         mailproc = subprocess.Popen(bash_cmd.split(), stdout=subprocess.PIPE)


### PR DESCRIPTION
## Description

In v4.2.4 we attemtped to add a space, but this was not tested, which when deployed caused mailjobs to not be submitted. In this PR we will add back the option, and run this properly in stage before launching to prod.

### Primary function of PR

- [x] Hot-fix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

## Testing

<!-- If the update is a hot-fix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR. -->

- `bash /home/proj/production/servers/resources/hasta.scilifelab.se/install-microsalt-stage.sh BRANCHNAME`
- `us`
- `conda activate S_microSALT`
- `microSALT analyse --input /path/to/fastq/ SAMPLEINFO_FILE`

### Test results

_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

## Sign-offs

- [ ] Approved to run at Clinical-Genomics by @karlnyr or @Clinical-Genomics/micro
