### PR TITLE
Replace Flask with standalone Jinja2 rendering

### DIFF
--- a/microSALT/server/app.py
+++ b/microSALT/server/app.py
@@ -1,4 +1,0 @@
-from microSALT.server.views import app
-
-if __name__ == "__main__":
-    app.run()

--- a/microSALT/server/templates/typing_page.html
+++ b/microSALT/server/templates/typing_page.html
@@ -10,7 +10,7 @@
               <img src="https://github.com/Clinical-Genomics/microSALT/blob/master/artwork/microsalt.jpg?raw=true" \
               alt="MicroSALT Logo" align="left" \
               style="position:absolute;left:15px;width:400px;height:100px;display:flex;"></a>
-              {% if 'MW' in topsample.application_tag %}
+              {% if topsample.application_tag and 'MW' in topsample.application_tag %}
                 <img src="https://github.com/Clinical-Genomics/microSALT/blob/master/artwork/swedac.jpg?raw=true" alt="Swedac Logo" align="right" style="display:flex;">
               {% endif %}
               <h2 class="page-header">
@@ -282,7 +282,7 @@
         	    </tr>
         	    <tr>
         	      <th scope="row" >Analys datum</th>
-        	      <td>{{sample.date_analysis.date()}}</td>
+        	      <td>{% if sample.date_analysis is not none %}{{sample.date_analysis.date()}}{% endif %}</td>
         	    </tr>
         	    <tr>
         	      <th scope="row" >Organism</th>

--- a/microSALT/server/views.py
+++ b/microSALT/server/views.py
@@ -1,75 +1,81 @@
-import math
 import logging
 import subprocess
-
 from datetime import date
-from flask import Flask, render_template
-from io import StringIO, BytesIO
+from pathlib import Path
 
-from sqlalchemy import *
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.sql import *
-from sqlalchemy.sql.expression import case, func
+from jinja2 import Environment, FileSystemLoader
 
-from microSALT import preset_config, __version__
-from microSALT.store.db_manipulator import app
+from microSALT import __version__, preset_config
 from microSALT.store.orm_models import (
     Collections,
-    Projects,
     Reports,
     Samples,
-    Seq_types,
     Versions,
 )
 
-engine = create_engine(
-    app.config["SQLALCHEMY_DATABASE_URI"], connect_args={"check_same_thread": False,'timeout':15}
-)
-Session = sessionmaker(bind=engine)
-session = Session()
-app.debug = 0
+from microSALT.store.database import get_session
+
 # Removes server start messages
 log = logging.getLogger("werkzeug")
 log.setLevel(logging.CRITICAL)
 
-
-@app.route("/")
-def start_page():
-    projects = session.query(Projects).all()
-    session.close()
-    return render_template("start_page.html", projects=projects)
+TEMPLATE_FOLDER = Path(__file__).parent / "templates"
 
 
-@app.route("/microSALT/")
-def reroute_page():
-    projects = session.query(Projects).all()
-    session.close()
-    return render_template("start_page.html", projects=projects)
+def _make_url_for(project=None):
+    """Creates a url_for stub for use in static Jinja2 templates."""
+
+    def url_for(endpoint, **kwargs):
+        if endpoint == "static":
+            return kwargs.get("filename", "")
+        elif endpoint == "start_page":
+            return "#"
+        elif endpoint == "project_page":
+            p = kwargs.get("project", project or "")
+            return "#project-{}".format(p)
+        elif endpoint == "typing_page":
+            p = kwargs.get("project", project or "")
+            og = kwargs.get("organism_group", "all")
+            return "#typing-{}-{}".format(p, og)
+        return "#"
+
+    return url_for
 
 
-@app.route("/microSALT/<project>")
-def project_page(project):
+def render_template(template_folder, template_name, **context):
+    """Renders a template using Jinja2 directly to avoid Flask overhead"""
+    template_loader = FileSystemLoader(searchpath=str(template_folder))
+    jinja_env = Environment(loader=template_loader)
+    template = jinja_env.get_template(template_name)
+    if "url_for" not in context:
+        context["url_for"] = _make_url_for()
+    return template.render(**context)
+
+
+def project_page(project, template_folder: Path = TEMPLATE_FOLDER):
+    session = get_session()
     organism_groups = list()
     organism_groups.append("all")
-    distinct_organisms = (
-        session.query(Samples).filter_by(CG_ID_project=project).distinct()
-    )
-    session.close()
+    distinct_organisms = session.query(Samples).filter_by(CG_ID_project=project).distinct()
     for one_guy in distinct_organisms:
         if one_guy.organism not in organism_groups and one_guy.organism is not None:
             organism_groups.append(one_guy.organism)
     organism_groups.sort()
     return render_template(
-        "project_page.html", organisms=organism_groups, project=project
+        template_folder=template_folder,
+        template_name="project_page.html",
+        organisms=organism_groups,
+        project=project,
+        url_for=_make_url_for(project),
     )
 
 
-@app.route("/microSALT/<project>/qc")
-def alignment_page(project):
+def alignment_page(project, template_folder: Path = TEMPLATE_FOLDER):
     sample_info = gen_reportdata(project)
 
     return render_template(
-        "alignment_page.html",
+        template_folder=template_folder,
+        template_name="alignment_page.html",
         samples=sample_info["samples"],
         topsample=sample_info["single_sample"],
         date=date.today().isoformat(),
@@ -81,12 +87,16 @@ def alignment_page(project):
     )
 
 
-@app.route("/microSALT/<project>/typing/<organism_group>")
-def typing_page(project, organism_group):
+def render_alignment_page(project, template_folder: Path = TEMPLATE_FOLDER):
+    return alignment_page(project, template_folder=template_folder)
+
+
+def typing_page(project, organism_group, template_folder: Path = TEMPLATE_FOLDER):
     sample_info = gen_reportdata(project, organism_group)
 
     return render_template(
-        "typing_page.html",
+        template_folder=template_folder,
+        template_name="typing_page.html",
         samples=sample_info["samples"],
         topsample=sample_info["single_sample"],
         date=date.today().isoformat(),
@@ -99,9 +109,12 @@ def typing_page(project, organism_group):
     )
 
 
-@app.route("/microSALT/STtracker/<customer>")
-def STtracker_page(customer):
-    sample_info = gen_reportdata(pid="all", organism_group="all")
+def render_typing_page(project, organism_group, template_folder: Path = TEMPLATE_FOLDER):
+    return typing_page(project, organism_group, template_folder=template_folder)
+
+
+def STtracker_page(customer, template_folder: Path = TEMPLATE_FOLDER):
+    sample_info = gen_reportdata(project_id="all", organism_group="all")
     final_samples = list()
     for s in sample_info["samples"]:
         if customer == "all" or s.projects.Customer_ID == customer:
@@ -111,51 +124,48 @@ def STtracker_page(customer):
     final_samples = sorted(final_samples, key=lambda sample: (sample.CG_ID_sample))
 
     return render_template(
-        "STtracker_page.html", date=date.today().isoformat(), internal=final_samples
+        template_folder=template_folder,
+        template_name="STtracker_page.html",
+        date=date.today().isoformat(),
+        internal=final_samples,
     )
 
 
 def gen_collectiondata(collect_id=[]):
-    """ Queries database using a set of samples"""
-    arglist = []
-    samples = (
-        session.query(Collections).filter(Collections.ID_collection == collect_id).all()
-    )
-    for sample in samples:
-        arglist.append("Samples.CG_ID_sample=='{}'".format(sample.CG_ID_sample))
-    sample_info = session.query(Samples).filter(
-        eval("or_({})".format(",".join(arglist)))
-    )
+    """Queries database using a set of samples"""
+    session = get_session()
+    samples = session.query(Collections).filter(Collections.ID_collection == collect_id).all()
+    sample_ids = [s.CG_ID_sample for s in samples]
+    sample_info = session.query(Samples).filter(Samples.CG_ID_sample.in_(sample_ids))
     sample_info = gen_add_info(sample_info)
     return sample_info
 
 
-def gen_reportdata(pid="all", organism_group="all"):
-    """ Queries database for all necessary information for the reports """
-    if pid == "all" and organism_group == "all":
+def gen_reportdata(project_id="all", organism_group="all"):
+    """Queries database for all necessary information for the reports"""
+    session = get_session()
+    if project_id == "all" and organism_group == "all":
         sample_info = session.query(Samples)
-    elif pid == "all":
+    elif project_id == "all":
         sample_info = session.query(Samples).filter(Samples.organism == organism_group)
     elif organism_group == "all":
-        sample_info = session.query(Samples).filter(Samples.CG_ID_project == pid)
+        sample_info = session.query(Samples).filter(Samples.CG_ID_project == project_id)
     else:
         sample_info = session.query(Samples).filter(
-            Samples.CG_ID_project == pid, Samples.organism == organism_group
+            Samples.CG_ID_project == project_id, Samples.organism == organism_group
         )
 
     sample_info = gen_add_info(sample_info)
 
-    reports = session.query(Reports).filter(Reports.CG_ID_project == pid).all()
-    session.close()
-    sample_info["reports"] = reports = sorted(
-        reports, key=lambda x: x.version, reverse=True
-    )
+    reports = session.query(Reports).filter(Reports.CG_ID_project == project_id).all()
+    sample_info["reports"] = reports = sorted(reports, key=lambda x: x.version, reverse=True)
 
     return sample_info
 
 
 def gen_add_info(sample_info=dict()):
-    """ Enhances a sample info struct by adding ST_status, threshold info, versioning and sorting """
+    """Enhances a sample info struct by adding ST_status, threshold info, versioning and sorting"""
+    session = get_session()
     # Set ST status
     output = dict()
     output["samples"] = list()
@@ -172,11 +182,9 @@ def gen_add_info(sample_info=dict()):
         try:
             sample_info = sorted(
                 sample_info,
-                key=lambda sample: int(
-                    sample.CG_ID_sample.replace(sample.CG_ID_project, "")[1:]
-                ),
+                key=lambda sample: int(sample.CG_ID_sample.replace(sample.CG_ID_project, "")[1:]),
             )
-        except ValueError as e:
+        except ValueError:
             pass
 
     for s in sample_info:
@@ -219,7 +227,7 @@ def gen_add_info(sample_info=dict()):
                     s.threshold = "Failed"
 
             if near_hits > 0 and s.threshold == "Passed":
-                s.ST_status = "Okänd ({} allele[r])".format(near_hits)
+                s.ST_status = f"Okänd ({near_hits} allele[r])"
         else:
             s.threshold = "Failed"
 
@@ -257,7 +265,6 @@ def gen_add_info(sample_info=dict()):
         output["single_sample"] = s
 
     versions = session.query(Versions).all()
-    session.close()
     for version in versions:
         name = version.name[8:]
         output["versions"][name] = version.version

--- a/microSALT/store/database.py
+++ b/microSALT/store/database.py
@@ -1,0 +1,36 @@
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
+
+from microSALT.exc.exceptions import MicroSALTError
+
+session: scoped_session | None = None
+engine: Engine | None = None
+
+
+def initialize_database(db_uri: str) -> None:
+    """Initialize the SQLAlchemy engine and session for status db."""
+    global engine, session
+
+    engine = create_engine(db_uri, pool_pre_ping=True)
+    session_factory = sessionmaker(engine)
+    session = scoped_session(session_factory)
+
+
+def get_session() -> Session:
+    """Get a SQLAlchemy session with a connection to status db."""
+    if not session:
+        raise MicroSALTError("Database not initialised")
+    return session
+
+
+def get_scoped_session_registry() -> scoped_session | None:
+    """Get the scoped session registry for status db."""
+    return session
+
+
+def get_engine() -> Engine:
+    """Get the SQLAlchemy engine with a connection to status db."""
+    if not engine:
+        raise MicroSALTError("Database not initialised")
+    return engine


### PR DESCRIPTION
Flask and Flask-SQLAlchemy are removed from the dependency tree. The server layer is replaced with pure Jinja2 template rendering:

- views.py: convert @app.route handlers into plain functions that return rendered HTML strings; add a url_for stub so templates continue to work without a running Flask application context
- store/database.py: new module that owns the SQLAlchemy engine and scoped-session registry, decoupling session lifecycle from Flask
- server/app.py: deleted (no longer needed)
- Add werkzeug as an explicit dependency (used for password hashing)

## Description

<!-- Summary of the changes made. If not self-evident, mention what prompted the change. -->

### Primary function of PR

- [ ] Hot-fix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

## Testing

<!-- If the update is a hot-fix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR. -->

- `bash /home/proj/production/servers/resources/hasta.scilifelab.se/install-microsalt-stage.sh BRANCHNAME`
- `us`
- `conda activate S_microSALT`
- `microSALT analyse --input /path/to/fastq/ SAMPLEINFO_FILE`

### Test results

_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

## Sign-offs

- [ ] Approved to run at Clinical-Genomics by @karlnyr or @Clinical-Genomics/micro
