### PR TITLE
Rename CLI entry point from microSALT to microsalt

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ export MICROSALT_CONFIG=/MY/FAV/FOLDER/config.json
 
 ## Usage
 
-- `microSALT analyse` contains functions to start sbatch job(s) & produce
+- `microsalt analyse` contains functions to start sbatch job(s) & produce
   output to `folders['results']`. Afterwards the parsed results are uploaded
   to the SQL back-end and produce reports (HTML), which are then automatically
   e-mailed to the user.
-- `microSALT utils` contains various functionality, including generating the
+- `microsalt utils` contains various functionality, including generating the
   sample description json, manually adding new reference organisms and
   re-generating reports.
 

--- a/microSALT/utils/job_creator.py
+++ b/microSALT/utils/job_creator.py
@@ -586,7 +586,7 @@ class Job_Creator:
                 mb.write(f"export MICROSALT_CONFIG={os.environ['MICROSALT_CONFIG']}\n")
             conda_cmd = (
                 f"conda run -p {os.environ['CONDA_PREFIX']} "
-                f"microSALT utils finish {self.finishdir}/sampleinfo.json "
+                f"microsalt utils finish {self.finishdir}/sampleinfo.json "
                 f"--input {self.finishdir} "
                 f"--email {self.config['regex']['mail_recipient']} "
                 f"--report {report} "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 [project.scripts]
-microSALT = "microSALT.cli:root"
+microsalt = "microSALT.cli:root"
 
 [project.urls]
 Homepage = "https://github.com/Clinical-Genomics/microSALT"


### PR DESCRIPTION
Change the `project.scripts` entry in `pyproject.toml` so that the installed command is '`microsalt`' (all lowercase). Update usage examples in `README.md` and the finish-job sbatch script in `job_creator.py` to use the new name.

## Description

<!-- Summary of the changes made. If not self-evident, mention what prompted the change. -->

### Primary function of PR

- [ ] Hot-fix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

## Testing

<!-- If the update is a hot-fix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR. -->

- `bash /home/proj/production/servers/resources/hasta.scilifelab.se/install-microsalt-stage.sh BRANCHNAME`
- `us`
- `conda activate S_microSALT`
- `microSALT analyse --input /path/to/fastq/ SAMPLEINFO_FILE`

### Test results

_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

## Sign-offs

- [ ] Approved to run at Clinical-Genomics by @karlnyr or @Clinical-Genomics/micro
