### PR TITLE
Remove conda prefix dependency and update job finish command to use microsalt binary

### DIFF
--- a/microSALT/utils/job_creator.py
+++ b/microSALT/utils/job_creator.py
@@ -646,6 +646,23 @@ class Job_Creator:
         if not dry:
             self.finish_job(jobarray, single_sample)
 
+    def _write_mailjob(self, mailfile: str, report: str, custom_conf: str) -> None:
+        """Write the mailjob.sh script that runs `microsalt utils finish` after all jobs complete."""
+        _ep = next(ep for ep in entry_points(group="console_scripts") if ep.value == "microSALT.cli:root")
+        microsalt_bin = Path(sys.executable).parent / _ep.name
+        with open(mailfile, "w+") as mb:
+            mb.write("#!/usr/bin/env bash\n\n")
+            mb.write("#Uploading of results to database and production of report\n")
+            finish_cmd = (
+                f"{microsalt_bin} --config {self.config_path} utils finish {self.finishdir}/sampleinfo.json "
+                f"--input {self.finishdir} "
+                f"--email {self.regex.mail_recipient} "
+                f"--report {report} "
+                f"{custom_conf}\n"
+            )
+            mb.write(finish_cmd)
+            mb.write(f"touch {self.finishdir}/run_complete.out\n")
+
     def finish_job(self, joblist, single_sample=False):
         """Uploads data and sends an email once all analysis jobs are complete."""
         report = "default"
@@ -679,20 +696,7 @@ class Job_Creator:
             cb.write(f"ANALYSIS STARTED BY: {user}\n")
             cb.write(json.dumps(configout, indent=2, separators=(",", ":")))
 
-        _ep = next(ep for ep in entry_points(group="console_scripts") if ep.value == "microSALT.cli:root")
-        microsalt_bin = Path(sys.executable).parent / _ep.name
-        with open(mailfile, "w+") as mb:
-            mb.write("#!/usr/bin/env bash\n\n")
-            mb.write("#Uploading of results to database and production of report\n")
-            finish_cmd = (
-                f"{microsalt_bin} --config {self.config_path} utils finish {self.finishdir}/sampleinfo.json "
-                f"--input {self.finishdir} "
-                f"--email {self.regex.mail_recipient} "
-                f"--report {report} "
-                f"{custom_conf}\n"
-            )
-            mb.write(finish_cmd)
-            mb.write(f"touch {self.finishdir}/run_complete.out\n")
+        self._write_mailjob(mailfile, report, custom_conf)
 
         massagedJobs = list()
         final = ":".join(joblist)

--- a/microSALT/utils/job_creator.py
+++ b/microSALT/utils/job_creator.py
@@ -10,7 +10,8 @@ import os
 import re
 import shutil
 import subprocess
-from sys import executable
+import sys
+from importlib.metadata import entry_points
 import time
 from datetime import datetime
 from pathlib import Path
@@ -678,7 +679,8 @@ class Job_Creator:
             cb.write(f"ANALYSIS STARTED BY: {user}\n")
             cb.write(json.dumps(configout, indent=2, separators=(",", ":")))
 
-        microsalt_bin = Path(executable).parent / "microsalt"
+        _ep = next(ep for ep in entry_points(group="console_scripts") if ep.value == "microSALT.cli:root")
+        microsalt_bin = Path(sys.executable).parent / _ep.name
         with open(mailfile, "w+") as mb:
             mb.write("#!/usr/bin/env bash\n\n")
             mb.write("#Uploading of results to database and production of report\n")

--- a/microSALT/utils/job_creator.py
+++ b/microSALT/utils/job_creator.py
@@ -10,6 +10,7 @@ import os
 import re
 import shutil
 import subprocess
+from sys import executable
 import time
 from datetime import datetime
 from pathlib import Path
@@ -677,20 +678,18 @@ class Job_Creator:
             cb.write(f"ANALYSIS STARTED BY: {user}\n")
             cb.write(json.dumps(configout, indent=2, separators=(",", ":")))
 
+        microsalt_bin = Path(executable).parent / "microsalt"
         with open(mailfile, "w+") as mb:
             mb.write("#!/usr/bin/env bash\n\n")
             mb.write("#Uploading of results to database and production of report\n")
-            if "MICROSALT_CONFIG" in os.environ:
-                mb.write(f"export MICROSALT_CONFIG={os.environ['MICROSALT_CONFIG']}\n")
-            conda_cmd = (
-                f"conda run -p {os.environ['CONDA_PREFIX']} "
-                f"microsalt utils finish {self.finishdir}/sampleinfo.json "
+            finish_cmd = (
+                f"{microsalt_bin} --config {self.config_path} utils finish {self.finishdir}/sampleinfo.json "
                 f"--input {self.finishdir} "
                 f"--email {self.regex.mail_recipient} "
                 f"--report {report} "
                 f"{custom_conf}\n"
             )
-            mb.write(conda_cmd)
+            mb.write(finish_cmd)
             mb.write(f"touch {self.finishdir}/run_complete.out\n")
 
         massagedJobs = list()

--- a/tests/utils/test_jobcreator.py
+++ b/tests/utils/test_jobcreator.py
@@ -178,3 +178,54 @@ def test_singularity_exec_does_not_duplicate_finishdir(config, logger, testdata)
     )
     cmd = jc._singularity_exec("blast", "blastn -help")
     assert cmd.count("/tmp/test_runfolder") == 1
+
+
+def _make_jc(config, logger, testdata, tmp_path) -> Job_Creator:
+    return Job_Creator(
+        log=logger,
+        folders=config.folders,
+        slurm_header=config.slurm_header,
+        regex=config.regex,
+        dry=False,
+        config_path=config.config_path,
+        threshold=config.threshold,
+        pubmlst=config.pubmlst,
+        pasteur=config.pasteur,
+        singularity=config.singularity,
+        containers=config.containers,
+        sampleinfo=testdata,
+        run_settings={"input": "/tmp/", "finishdir": str(tmp_path)},
+    )
+
+
+def test_write_mailjob_uses_existing_executable(config, logger, testdata, tmp_path):
+    """The binary embedded in mailjob.sh must exist on the filesystem."""
+    import pathlib
+    jc = _make_jc(config, logger, testdata, tmp_path)
+    mailfile = str(tmp_path / "mailjob.sh")
+
+    jc._write_mailjob(mailfile, "default", "")
+
+    content = pathlib.Path(mailfile).read_text()
+    # Extract the first token of the finish command (the binary path)
+    bin_path = next(
+        line.split()[0]
+        for line in content.splitlines()
+        if "utils finish" in line
+    )
+    assert pathlib.Path(bin_path).exists(), f"Binary not found on disk: {bin_path}"
+
+
+def test_write_mailjob_contains_finish_command(config, logger, testdata, tmp_path):
+    """mailjob.sh must contain the expected microsalt utils finish invocation."""
+    import pathlib
+    jc = _make_jc(config, logger, testdata, tmp_path)
+    mailfile = str(tmp_path / "mailjob.sh")
+
+    jc._write_mailjob(mailfile, "qc", "")
+
+    content = pathlib.Path(mailfile).read_text()
+    assert "utils finish" in content
+    assert "--report qc" in content
+    assert str(tmp_path) in content
+


### PR DESCRIPTION
## Description

This PR addresses the need of conda on the system to run it. With the changes, conda can now be an alternative as a enviroment handler, as we now only point to the microSALT executable

### Primary function of PR

- [ ] Hot-fix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

## Testing

<!-- If the update is a hot-fix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR. -->

- `bash /home/proj/production/servers/resources/hasta.scilifelab.se/install-microsalt-stage.sh BRANCHNAME`
- `us`
- `conda activate S_microSALT`
- `microSALT analyse --input /path/to/fastq/ SAMPLEINFO_FILE`

### Test results

_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

## Sign-offs

- [ ] Approved to run at Clinical-Genomics by @karlnyr or @Clinical-Genomics/micro
