### PR TITLE
Stop updating references when using pipeline

### DIFF
--- a/microSALT/cli.py
+++ b/microSALT/cli.py
@@ -238,13 +238,14 @@ def analyse(
     try:
         ext_refs.db_access.check_ref_lock()
     except RefUpdateLockError as e:
-        click.echo("ERROR - {}".format(e))
+        click.echo(f"ERROR - {e}")
         click.Abort()
     click.echo("INFO - Checking versions of references..")
     try:
         if not skip_update:
+            # This will pull fasta files for references in project and fasta for new ST profiles.
+            # It does cause the start to take time, but at least it does not lock the database
             ext_refs.identify_new(project=True)
-            ext_refs.update_refs()
             click.echo("INFO - Version check done. Creating sbatch jobs")
         else:
             click.echo("INFO - Skipping version check.")

--- a/microSALT/cli.py
+++ b/microSALT/cli.py
@@ -2,7 +2,6 @@
 By: Isak Sylvin, @sylvinite"""
 
 #!/usr/bin/env python
-
 import json
 import logging
 import os
@@ -21,8 +20,9 @@ from microSALT.store.database import (
     get_scoped_session_registry,
     initialize_database,
 )
+from microSALT.store.db_manipulator import DB_Manipulator
 from microSALT.utils.job_creator import Job_Creator
-from microSALT.utils.pubmlst.get_credentials import main as get_bigsdb_credentials_main
+from microSALT.utils.pubmlst.get_credentials import get_bigsdb_access_token
 from microSALT.utils.referencer import Referencer
 from microSALT.utils.reporter import Reporter
 from microSALT.utils.scraper import Scraper
@@ -298,9 +298,7 @@ def refer(ctx):
 )
 @click.option("--output", help="Report output folder", default="")
 @pass_config
-def finish(
-    config: MicroSALTConfig, sampleinfo_file, input, track, dry, email, skip_update, report, output
-):
+def finish(config: MicroSALTConfig, sampleinfo_file, input, track, dry, email, report, output):
     """Sequence analysis, typing and resistance identification"""
     pool = []
     if email:
@@ -316,31 +314,12 @@ def finish(
             pool.append(subfolder)
 
     sampleinfo = review_sampleinfo(sampleinfo_file)
-    ext_refs = Referencer(
-        log=logger,
-        folders=config.folders,
-        threshold=config.threshold,
-        pubmlst=config.pubmlst,
-        pasteur=config.pasteur,
-        singularity=config.singularity,
-        containers=config.containers,
-        sampleinfo=sampleinfo,
-    )
+    db_manipulator = DB_Manipulator(log=logger, folders=config.folders, threshold=config.threshold)
     try:
-        ext_refs.db_access.check_ref_lock()
+        db_manipulator.check_ref_lock()
     except RefUpdateLockError as e:
-        click.echo("ERROR - {}".format(e))
+        click.echo(f"ERROR - {e}")
         click.Abort()
-    click.echo("INFO - Checking versions of references..")
-    try:
-        if not skip_update:
-            ext_refs.identify_new(project=True)
-            ext_refs.update_refs()
-            click.echo("INFO - Version check done. Creating sbatch jobs")
-        else:
-            click.echo("INFO - Skipping version check.")
-    except Exception as e:
-        click.echo(f"{e}")
 
     res_scraper = Scraper(
         log=logger,
@@ -463,7 +442,7 @@ def report(config: MicroSALTConfig, sampleinfo_file, email, type, output, collec
 @pass_config
 def get_bigsdb_credentials(config: MicroSALTConfig, service, species):
     """Obtain and store BIGSdb OAuth credentials for SERVICE (pubmlst or pasteur)"""
-    get_bigsdb_credentials_main(service, config, species)
+    get_bigsdb_access_token(service, config, species)
 
 
 @utils.command()

--- a/microSALT/cli.py
+++ b/microSALT/cli.py
@@ -243,9 +243,8 @@ def analyse(
     click.echo("INFO - Checking versions of references..")
     try:
         if not skip_update:
-            # This will pull fasta files for references in project and fasta for new ST profiles.
-            # It does cause the start to take time, but at least it does not lock the database
-            ext_refs.identify_new(project=True)
+            new_orgs = ext_refs.identify_new(project=True)
+            ext_refs.create_new_profile_tables(new_orgs)
             click.echo("INFO - Version check done. Creating sbatch jobs")
         else:
             click.echo("INFO - Skipping version check.")

--- a/microSALT/store/db_manipulator.py
+++ b/microSALT/store/db_manipulator.py
@@ -394,6 +394,33 @@ class DB_Manipulator:
             )
             self.reload_profiletable(organism)
 
+    def create_profile_table(self, organism: str) -> None:
+        """Create and populate a profile table for a newly downloaded organism.
+
+        Intended for use after add_pubmlst() has written the profile CSV and loci
+        files to disk for an organism that does not yet have a DB table. Silently
+        skips if the table already exists, so it is safe to call speculatively.
+        """
+        inspector = sa_inspect(self.engine)
+        if inspector.has_table(f"profile_{organism}"):
+            self.logger.info(f"Profile table profile_{organism} already exists, skipping.")
+            return
+        fresh_metadata = MetaData()
+        fresh_profiles = ProfileTable(
+            "profile_", fresh_metadata, self.folders.profiles, self.logger
+        ).tables
+        if organism not in fresh_profiles:
+            self.logger.warning(
+                f"Profile file for {organism} not found on disk, cannot create table."
+            )
+            return
+        table = fresh_profiles[organism]
+        table.create(self.engine)
+        self.populate_profiletable(organism, table)
+        self.add_to_session(self.add_version(name=f"profile_{organism}", version="0"))
+        self.commit_session()
+        self.logger.info(f"Created and populated profile table for {organism}")
+
     def populate_profiletable(self, filename: str, table) -> None:
         """Bulk-inserts all data rows from a profile file into an already-created *table*."""
         file_path = f"{self.folders.profiles}/{filename}"

--- a/microSALT/utils/pubmlst/get_credentials.py
+++ b/microSALT/utils/pubmlst/get_credentials.py
@@ -77,7 +77,7 @@ def save_to_credentials_py(
     print(f"Tokens saved to {credentials_file}")
 
 
-def main(service: str, config: MicroSALTConfig, species: str | None = None):
+def get_bigsdb_access_token(service: str, config: MicroSALTConfig, species: str | None = None):
     try:
         service_config = get_service_config(service, pubmlst=config.pubmlst, pasteur=config.pasteur)
         bigsd_config = service_config["config"]

--- a/microSALT/utils/referencer.py
+++ b/microSALT/utils/referencer.py
@@ -2,6 +2,7 @@
 By: Isak Sylvin, @sylvinite"""
 
 #!/usr/bin/env python
+from typing import cast
 import glob
 import os
 import re
@@ -85,10 +86,17 @@ class Referencer:
         bind = f"--bind {','.join(bind_list)}" if bind_list else ""
         return f"{binary} exec {bind} {sif} {command}"
 
-    def identify_new(self, cg_id="", project=False):
-        """Automatically downloads pubMLST & NCBI organisms not already downloaded"""
-        neworgs = list()
-        newrefs = list()
+    def identify_new(self) -> list[str]:
+        """Download pubMLST & NCBI resources for organisms not already present.
+
+        Returns a list of internal organism names (e.g. "staphylococcus_aureus")
+        for which profile files were successfully downloaded. These names can be
+        passed directly to create_new_profile_tables() to persist the profiles in
+        the database without performing a full reference update.
+        """
+        neworgs: list[str] = []
+        newrefs: list[str] = []
+        downloaded: list[str] = []
         try:
             if not isinstance(self.sampleinfo, list):
                 samples = [self.sampleinfo]
@@ -104,15 +112,29 @@ class Referencer:
                     f"{entry.get('reference')}.fasta" not in os.listdir(self.folders.genomes)
                     and entry.get("reference") not in newrefs
                 ):
-                    newrefs.append(entry.get("reference"))
+                    newrefs.append(cast(str, entry.get("reference")))
             for org in neworgs:
-                self.add_pubmlst(org)
+                truename = self.add_pubmlst(org)
+                if truename is not None:
+                    downloaded.append(truename)
             for org in newrefs:
                 self.download_ncbi(org)
         except Exception:
             self.logger.error(
                 "Unable to retrieve reference! Analysis using said reference will fail!"
             )
+        return downloaded
+
+    def create_new_profile_tables(self, new_organisms: list[str]) -> None:
+        """Create database profile tables for organisms downloaded by identify_new().
+
+        This is a lightweight alternative to update_refs() for the case where an
+        organism is completely new to the system. Because the tables do not exist
+        yet there is no risk of a concurrent reader seeing a partially-updated
+        table, so no lock is acquired.
+        """
+        for organism in new_organisms:
+            self.db_access.create_profile_table(organism)
 
     def update_refs(self):
         """Updates all references. Order is important, since no object is updated twice"""
@@ -407,7 +429,7 @@ class Referencer:
         """Returns list of all organisms currently added"""
         return self.organisms
 
-    def organism2reference(self, normal_organism_name):
+    def organism2reference(self, normal_organism_name) -> str | None:
         """Finds which reference contains the same words as the organism
         and returns it in a format for database calls. Returns empty string if none found"""
         orgs = os.listdir(self.folders.references)
@@ -502,11 +524,14 @@ class Referencer:
                 truename = desc.lower().split(" ")
                 truename = f"{truename[0]}_{truename[1]}"
                 self.download_pubmlst(truename, seqdef_url, force=self.force)
-                # Update organism list
+                # Update in-memory organism list so subsequent identify_new calls
+                # in the same process see the new organism immediately.
                 self.refs = self.db_access.profiles
-                self.logger.info(f"Created table profile_{truename}")
+                self.logger.info(f"Downloaded profile files for {truename}")
+                return truename
         except Exception as e:
             self.logger.warning(e.args[0])
+        return None
 
     def query_pubmlst(self):
         """Returns a json object containing all organisms available via pubmlst.org"""

--- a/microSALT/utils/referencer.py
+++ b/microSALT/utils/referencer.py
@@ -464,6 +464,7 @@ class Referencer:
         """Checks pubmlst for references of given organism and downloads them"""
         # Organism must be in binomial format and only resolve to one hit
         errorg = organism
+        self.db_access.check_ref_lock()
         try:
             organism = organism.lower().replace(".", " ")
             if organism.replace(" ", "_") in self.organisms and not self.force:

--- a/microSALT/utils/reporter.py
+++ b/microSALT/utils/reporter.py
@@ -27,7 +27,17 @@ from microSALT.store.db_manipulator import DB_Manipulator
 
 
 class Reporter:
-    def __init__(self, log, folders: Folders, threshold: Threshold, regex: Regex, sampleinfo={}, name="", output="", collection=False):
+    def __init__(
+        self,
+        log,
+        folders: Folders,
+        threshold: Threshold,
+        regex: Regex,
+        sampleinfo={},
+        name="",
+        output="",
+        collection=False,
+    ):
         self.folders = folders
         self.threshold = threshold
         self.regex = regex
@@ -69,6 +79,7 @@ class Reporter:
         os.makedirs(f"{self.folders.reports}/analysis", exist_ok=True)
 
     def report(self, type="default", customer="all"):
+        self.db_pusher.check_ref_lock()
         self.create_subfolders()
         if type in ["default", "typing", "qc"]:
             # Only typing and qc reports are version controlled
@@ -152,7 +163,12 @@ class Reporter:
             self.logger.error(f"Project {self.name} does not exist")
             sys.exit(-1)
         try:
-            content = typing_page(self.name, "all", threshold=self.threshold, verified_organisms=self.regex.verified_organisms)
+            content = typing_page(
+                self.name,
+                "all",
+                threshold=self.threshold,
+                verified_organisms=self.regex.verified_organisms,
+            )
             outfile = f"{self.sample.get('Customer_ID_project')}_Typing_{last_version}.html"
             local = f"{self.output}/{outfile}"
             output = f"{self.folders.reports}/analysis/{outfile}"

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -49,7 +49,7 @@ def init_references(config: MicroSALTConfig, logger: logging.Logger, testdata: l
         containers=config.containers,
         sampleinfo=testdata,
     )
-    ref_obj.identify_new(testdata[0].get("CG_ID_project"), project=True)
+    ref_obj.identify_new()
     ref_obj.update_refs()
 
 

--- a/tests/utils/test_jobcreator.py
+++ b/tests/utils/test_jobcreator.py
@@ -203,7 +203,7 @@ def test_write_mailjob_uses_existing_executable(config, logger, testdata, tmp_pa
     jc = _make_jc(config, logger, testdata, tmp_path)
     mailfile = str(tmp_path / "mailjob.sh")
 
-    jc._write_mailjob(mailfile, "default", "")
+    jc._write_mailjob(mailfile, "default")
 
     content = pathlib.Path(mailfile).read_text()
     # Extract the first token of the finish command (the binary path)
@@ -221,7 +221,7 @@ def test_write_mailjob_contains_finish_command(config, logger, testdata, tmp_pat
     jc = _make_jc(config, logger, testdata, tmp_path)
     mailfile = str(tmp_path / "mailjob.sh")
 
-    jc._write_mailjob(mailfile, "qc", "")
+    jc._write_mailjob(mailfile, "qc")
 
     content = pathlib.Path(mailfile).read_text()
     assert "utils finish" in content


### PR DESCRIPTION
## Description

This removes the update of databases when we are running any command but the actual update references command.

### Primary function of PR

- [ ] Hot-fix
- [ ] Patch
- [ ] Minor functionality improvement
- [ ] New type of analysis
- [ ] Backward-breaking functionality improvement
- [ ] This change requires internal documents to be updated
- [ ] This change requires another repository to be updated

## Testing

<!-- If the update is a hot-fix, it is sufficient to rely on the development testing along with the Travis self-test automatically applied to the PR. -->

- `bash /home/proj/production/servers/resources/hasta.scilifelab.se/install-microsalt-stage.sh BRANCHNAME`
- `us`
- `conda activate S_microSALT`
- `microSALT analyse --input /path/to/fastq/ SAMPLEINFO_FILE`

### Test results

_These are the results of the tests, and necessary conclusions, that prove the stability of the PR._

## Sign-offs

- [ ] Approved to run at Clinical-Genomics by @karlnyr or @Clinical-Genomics/micro
